### PR TITLE
Fixed minpre/minpost calculation wich neither worked on hour borders nor...

### DIFF
--- a/timers.cpp
+++ b/timers.cpp
@@ -64,8 +64,8 @@ void TimersResponder::createOrUpdateTimer(ostream& out, cxxtools::http::Request&
            if (!v.IsPriorityValid(priority)) priority = 99;
            chan = VdrExtension::getChannel((const char*)event->ChannelID().ToString());
            if (!v.IsStartValid(start) || !v.IsStopValid(stop) || !v.IsDayValid(day)) {
-              time_t estart = event->StartTime();
-              time_t estop = event->EndTime();
+              time_t estart = event->StartTime()-minpre*60;
+              time_t estop = event->EndTime()+minpre*60;
               struct tm *starttime = localtime(&estart);
             
               ostringstream daystream;
@@ -74,10 +74,10 @@ void TimersResponder::createOrUpdateTimer(ostream& out, cxxtools::http::Request&
                         << StringExtension::addZeros((starttime->tm_mday), 2);
               day = daystream.str();
  
-              start = starttime->tm_hour * 100 + starttime->tm_min - ((int)(minpre/60))*100 - minpre%60;
+              start = starttime->tm_hour * 100 + starttime->tm_min;
 
               struct tm *stoptime = localtime(&estop);
-              stop = stoptime->tm_hour * 100 + stoptime->tm_min + ((int)(minpost/60))*100 + minpost%60;
+              stop = stoptime->tm_hour * 100 + stoptime->tm_min;
            }
         }
      } else {


### PR DESCRIPTION
... on day borders.

Hi guys. I really like your VDR plugin and I have started to write a client side web frontend using the REST API (soon on Github). During testing I found this bug and the fix was pretty easy. Maybe I got the concept wrong so this might be subject to discussion. It follows a simple test case:

``` c
#include <stdio.h>
#include <time.h>

int main(int argc, char **argv) {
    time_t estart = 86400*360*44 + 0*60*60;
    time_t estop = estart + 90*60;
    int start, stop;
    int minpre, minpost;
    struct tm *starttime, *stoptime;
    char buf[128];

    minpre = 5;
    minpost = 5;

    starttime = gmtime(&estart);
    start = starttime->tm_hour * 100 + starttime->tm_min - ((int)(minpre/60))*100 - minpre%60;

    strftime (buf, 128, "%Y-%m-%d %H:%M:%S %Z", starttime);
    printf("stime = %s\n", buf);

    stoptime = gmtime(&estop);
    stop = stoptime->tm_hour * 100 + stoptime->tm_min + ((int)(minpost/60))*100 + minpost%60;

    strftime (buf, 128, "%Y-%m-%d %H:%M:%S %Z", stoptime);
    printf("etime = %s\n", buf);

    printf("WRONG VERSION\n");
    printf("start = %04d\n", start);
    printf("stop = %04d\n", stop);

    printf("\n");
    printf("CORRECT VERSION\n");

    estart -= minpre*60;
    estop += minpost*60;
    starttime = gmtime(&estart);
    start = starttime->tm_hour * 100 + starttime->tm_min;

    stoptime = gmtime(&estop);
    stop = stoptime->tm_hour * 100 + stoptime->tm_min;

    strftime (buf, 128, "%Y-%m-%d %H:%M:%S %Z", stoptime);

    printf("start = %04d\n", start);
    printf("stop = %04d\n", stop);

    return 0;
}
```
