### PR TITLE
Bundled Fix/Features

### DIFF
--- a/epgsearch/services.h
+++ b/epgsearch/services.h
@@ -157,7 +157,7 @@ class cServiceHandler
 struct Epgsearch_services_v1_0
 {
 // in/out
-      std::auto_ptr<cServiceHandler> handler;
+      std::unique_ptr<cServiceHandler> handler;
 };
 
 // Data structures for service "Epgsearch-services-v1.1"
@@ -173,7 +173,7 @@ class cServiceHandler_v1_1 : public cServiceHandler
 struct Epgsearch_services_v1_1
 {
 // in/out
-      std::auto_ptr<cServiceHandler_v1_1> handler;
+      std::unique_ptr<cServiceHandler_v1_1> handler;
 };
 
 // Data structures for service "Epgsearch-services-v1.2"
@@ -189,7 +189,7 @@ class cServiceHandler_v1_2 : public cServiceHandler_v1_1
 struct Epgsearch_services_v1_2
 {
 // in/out
-      std::auto_ptr<cServiceHandler_v1_2> handler;
+      std::unique_ptr<cServiceHandler_v1_2> handler;
 };
 
 #endif

--- a/recordings.h
+++ b/recordings.h
@@ -68,6 +68,7 @@ private:
 
     virtual void reply(std::ostream& out, cxxtools::http::Request& request, cxxtools::http::Reply& reply);
     void deleteRecording(std::ostream& out, cxxtools::http::Request& request, cxxtools::http::Reply& reply);
+    void deleteRecordingByName(std::ostream& out, cxxtools::http::Request& request, cxxtools::http::Reply& reply);
     void showRecordings(std::ostream& out, cxxtools::http::Request& request, cxxtools::http::Reply& reply);
     void saveMarks(std::ostream& out, cxxtools::http::Request& request, cxxtools::http::Reply& reply);
     void deleteMarks(std::ostream& out, cxxtools::http::Request& request, cxxtools::http::Reply& reply);

--- a/restfulapi.cpp
+++ b/restfulapi.cpp
@@ -196,6 +196,12 @@ void cPluginRestfulapi::MainThreadHook(void)
   const cRecording* recording = scheduler->SwitchableRecording();
 
   if (recording != NULL) {
+     if (scheduler->IsRewind()) {
+        cDevice::PrimaryDevice()->StopReplay(); // must do this first to be able to rewind the currently replayed recording
+        cResumeFile ResumeFile(recording->FileName(), recording->IsPesRecording());
+        ResumeFile.Delete();
+        scheduler->SetRewind(false);
+     }
      cReplayControl::SetRecording(recording->FileName());
      scheduler->SwitchableRecording(NULL);
      cControl::Shutdown();

--- a/tools.cpp
+++ b/tools.cpp
@@ -830,7 +830,7 @@ bool VdrExtension::IsRecording(const cRecording* recording)
 const cTimer* VdrExtension::TimerExists(const cEvent* event)
 {
 
-#if APIVERSNUM > 20300
+#if APIVERSNUM > 20300  
     LOCK_TIMERS_READ;
     const cTimers& timers = *Timers;
 #else
@@ -859,7 +859,7 @@ const cTimer* VdrExtension::TimerExists(const cEvent* event)
         }
      }
   }
-  return NULL;
+    return NULL;
 }
 
 vector< const cTimer* > VdrExtension::SortedTimers()

--- a/tools.h
+++ b/tools.h
@@ -198,7 +198,6 @@ class FileExtension {
 class VdrExtension
 {
   private:
-    static bool MoveDirectory(std::string const & sourceDir, std::string const & targetDir, bool copy = false);
   public:
     static const cChannel* getChannel(int number);
     static const cChannel* getChannel(std::string id);
@@ -219,6 +218,7 @@ class VdrExtension
     static std::string getVideoDiskSpace();
     static std::string FileSystemExchangeChars(std::string const & s, bool ToFileSystem);
     static std::string MoveRecording(cRecording const * recording, std::string const & name, bool copy = false);
+    static bool MoveDirectory(std::string const & sourceDir, std::string const & targetDir, bool copy = false);
     static cDvbDevice* getDevice(int index);
 };
 
@@ -380,6 +380,7 @@ class TaskScheduler
     tChannelID _channel;
     const cRecording* _recording;
     cMutex     _channelMutex;
+    bool _bRewind;
   public:
     TaskScheduler() { _channel = tChannelID::InvalidID; _recording = NULL; };
     ~TaskScheduler();
@@ -390,6 +391,8 @@ class TaskScheduler
     tChannelID SwitchableChannel();
     void SwitchableRecording(const cRecording* recording) { _recording = recording; }
     const cRecording* SwitchableRecording() { return _recording; }
+    void SetRewind(bool bRewind) { _bRewind = bRewind; }
+    bool IsRewind() { return _bRewind; }
 };
 
 #endif


### PR DESCRIPTION
 Feature to update timer via timer_id, minpre, minpost
    
    "TimersResponder:CreateOrUpdateTimer" updated to update timer "minpre" and "minpost" property. 
    Sequence example e.g.: "curl -X PUT -v -H "Content-Type: application/json" -d 'timer_id=S19.2E-1-1019-10301:0:1550876400:1516:1758&minpre=15&minpost=8' localhost:8002/timers.json"

-Fix: NULL value in timer->Aux() field was leading into an error, Fixed in TimersResponder::createOrUpdateTimer(
- Fix timer deadlock
- applied patched from vdr forum, https://www.vdr-portal.de/forum/index.php?thread/131645-restfulapi-fix/&postID=1303965&highlight=restfulapi#post1303965