### PR TITLE
fix(QueryHandler): use `std::shared_ptr` for `jsonObject`

### DIFF
--- a/tools.cpp
+++ b/tools.cpp
@@ -1601,7 +1601,7 @@ QueryHandler::QueryHandler(string service, cxxtools::http::Request& request)
   }  
 
   if ( found_json ) {
-     jsonObject = jsonParser.Parse(body);
+     jsonObject.reset(jsonParser.Parse(body));
      esyslog("restfulapi: JSON parsed successfully: %s", jsonObject == NULL ? "no" : "yes");
   } else {
      _body.parse_url(body);
@@ -1615,13 +1615,6 @@ QueryHandler::QueryHandler(string service, cxxtools::http::Request& request)
   if ( (int)_url.find(".xml") != -1 ) { _format = ".xml"; }
   if ( (int)_url.find(".json") != -1 ) { _format = ".json"; }
   if ( (int)_url.find(".html") != -1 ) { _format = ".html"; }
-}
-
-QueryHandler::~QueryHandler()
-{
-  if (jsonObject != NULL) {
-     delete jsonObject;
-  }
 }
 
 /**

--- a/tools.h
+++ b/tools.h
@@ -7,6 +7,7 @@
 #include <exception>
 #include <iostream>
 #include <fstream>
+#include <memory>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -268,7 +269,7 @@ class QueryHandler
     cxxtools::QueryParams _options;
     cxxtools::QueryParams _body;
     JsonParser jsonParser;
-    JsonObject* jsonObject;
+    std::shared_ptr<JsonObject> jsonObject;
     std::string fixUrl(std::string url);
     void parseRestParams(std::string params);
     std::string getJsonString(std::string name);
@@ -277,7 +278,6 @@ class QueryHandler
     std::string _format;
   public:
     QueryHandler(std::string service, cxxtools::http::Request& request);
-    ~QueryHandler();
     bool has(std::string name);
     bool hasJson(std::string name);
     bool hasOption(std::string name);


### PR DESCRIPTION
The `QueryHandler` has

-   a raw pointer to a `JsonObject` that is freed in the destructor
-   an implicit copy constructor

The implicit copy-ctor copies the pointer only,
where it probably should do a deep copy.

This leads to use-after-free situations,
e.g. when calling `RecordingsResponder::getRecordingByRequest()` at the beginning of `RecordingsResponder::saveMarks()'.

A quick fix for the bug at hand is to make a deep copy of the `jsonObject`, that's what this commit is about.

An alternative variant would be to forbid copying of the `QueryHandler` and fix the fallout, e.g. by passing a reference (instead of a copy) of the `QueryHandler` instance to functions like
`RecordingsResponder::getRecordingByRequest()`.
Ideally a `const` reference would be passed, but that would incur more changes in to the `QueryHandler`, i.e. making all the `get*` and `has*` functions `const`, which are needlessly non-const currently.

I've opted for the smaller change (the quick fix), while I would probably prefer the alternative variant.

Let me know what you prefer.