### PR TITLE
fix -Wparentheses compiler warnings

### DIFF
--- a/epgsearch.cpp
+++ b/epgsearch.cpp
@@ -162,7 +162,7 @@ string SearchTimer::LoadCommonFromQuery(QueryHandler& q) {
   if ( search.length() > 0 ) { m_search = search; } else { return "Search required."; }
 
   m_mode = q.getBodyAsInt("mode");
-  if ( m_mode < 0 | m_mode > 5 )  { //0=phrase, 1=all words, 2=at least one word, 3=match exactly, 4=regex, 5=fuzzy
+  if ( m_mode < 0 || m_mode > 5 )  { //0=phrase, 1=all words, 2=at least one word, 3=match exactly, 4=regex, 5=fuzzy
       m_mode = 0;
   }
 

--- a/events.cpp
+++ b/events.cpp
@@ -527,7 +527,7 @@ void JsonEventList::addEvent(const cEvent* event)
   serEvent.TimerExists = timer != NULL ? true : false;
   serEvent.TimerActive = false;
   if ( timer != NULL ) {
-     serEvent.TimerActive = timer->Flags() & 0x01 == 0x01 ? true : false;
+     serEvent.TimerActive = (timer->Flags() & 0x01) != 0;
      serEvent.TimerId = StringExtension::UTF8Decode(VdrExtension::getTimerID(timer));
   }
 
@@ -606,7 +606,7 @@ void XmlEventList::addEvent(const cEvent* event)
   bool timer_active = false;
   string timer_id = "";
   if ( timer_exists ) {
-     timer_active = timer->Flags() & 0x01 == 0x01 ? true : false;
+     timer_active = (timer->Flags() & 0x01) != 0;
      timer_id = VdrExtension::getTimerID(timer);
   }
 


### PR DESCRIPTION
events.cpp: timer->Flags() & 0x01 == 0x01 has wrong precedence due to == binding tighter than &; use (flags & 0x01) != 0 instead.

epgsearch.cpp: bitwise | used instead of logical || in range check.