### PR TITLE
make default paths overridable at build time

### DIFF
--- a/tools.cpp
+++ b/tools.cpp
@@ -212,9 +212,9 @@ void Settings::initDefault()
 {
   SetPort((string)"8002");
   SetIp((string)"0.0.0.0");
-  SetEpgImageDirectory((string)"/var/cache/vdr/epgimages");
-  SetChannelLogoDirectory((string)"/usr/share/vdr/channel-logos");
-  SetWebappDirectory((string)"/var/lib/vdr/plugins/restfulapi/webapp");
+  SetEpgImageDirectory((string)EPG_IMAGE_DIR);
+  SetChannelLogoDirectory((string)CHANNEL_LOGO_DIR);
+  SetWebappDirectory((string)WEBAPP_DIR);
   SetHeaders((string)"true");
   webapp_filetypes_filename = "webapp_file_types.conf";
 }

--- a/tools.h
+++ b/tools.h
@@ -44,6 +44,18 @@
 #define DOCUMENT_ROOT "/var/lib/vdr/plugins/restfulapi/"
 #endif
 
+#ifndef WEBAPP_DIR
+#define WEBAPP_DIR "/var/lib/vdr/plugins/restfulapi/webapp"
+#endif
+
+#ifndef EPG_IMAGE_DIR
+#define EPG_IMAGE_DIR "/var/cache/vdr/epgimages"
+#endif
+
+#ifndef CHANNEL_LOGO_DIR
+#define CHANNEL_LOGO_DIR "/usr/share/vdr/channel-logos"
+#endif
+
 class Settings
 {
   private:


### PR DESCRIPTION
Add WEBAPP_DIR, EPG_IMAGE_DIR and CHANNEL_LOGO_DIR defines (analogous to the existing DOCUMENT_ROOT) so distribution-specific paths can be set via -D... in CXXFLAGS at build time without patching the source.