### PR TITLE
Makefile: replace cxxtools-config with pkg-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ SOFILE = libvdr-$(PLUGIN).so
 
 DEFINES += -DPLUGIN_NAME_I18N='"$(PLUGIN)"'
 
-LIBS    += $(shell cxxtools-config --libs) -lcxxtools-http
+LIBS    += $(shell pkg-config --libs cxxtools-http 2>/dev/null || { cxxtools-config --libs; echo -lcxxtools-http; })
 CONFDIR  = $(call PKGCFG,configdir)
 PLGCONFDIR = $(CONFDIR)/plugins/$(PLUGIN)
 


### PR DESCRIPTION
cxxtools-config was removed when cxxtools switched its build system to cmake; use pkg-config --libs cxxtools-http instead, which pulls in the library search path and cxxtools transitively via Requires:.

Fall back to cxxtools-config for older cxxtools releases that predate the cmake build.