### PR TITLE
Add SSE event stream for VDR change state

### DIFF
--- a/API.html
+++ b/API.html
@@ -2818,5 +2818,67 @@
             </section>
         </article>
     </div>
+
+<h2>Event stream</h2>
+
+<p>
+The RESTful API provides a Server-Sent Events stream for lightweight VDR state change notifications.
+The stream is available on the event stream port, which defaults to the configured REST port plus one.
+For example, if the REST API listens on port 8002, the event stream listens on port 8003.
+</p>
+
+<pre>
+GET /eventstream
+</pre>
+
+<p>
+The stream uses:
+</p>
+
+<pre>
+Content-Type: text/event-stream; charset=utf-8
+Cache-Control: no-cache
+Connection: keep-alive
+</pre>
+
+<p>
+The stream sends an initial hello event:
+</p>
+
+<pre>
+event: hello
+data: {"source":"restfulapi","bootID":"...","domains":[]}
+</pre>
+
+<p>
+State changes are emitted as vdr-change events. The event payload only contains the changed domains.
+Clients should use the event as an invalidation signal and reload the affected REST resources.
+</p>
+
+<pre>
+event: vdr-change
+id: 123456789
+data: {"source":"restfulapi","domains":["timers"]}
+</pre>
+
+<p>
+Known domains are:
+</p>
+
+<ul>
+  <li>channels</li>
+  <li>recordings</li>
+  <li>timers</li>
+  <li>events</li>
+</ul>
+
+<p>
+Heartbeat comments are sent periodically to keep the connection alive:
+</p>
+
+<pre>
+: heartbeat
+</pre>
+
 </body>
 </html>

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o remote.o timers.o changestate.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n

--- a/eventsstreamthread.cpp
+++ b/eventsstreamthread.cpp
@@ -1,0 +1,494 @@
+#include "eventsstreamthread.h"
+
+#include "changestatetracker.h"
+
+#include <vdr/tools.h>
+
+#include <algorithm>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <sstream>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+
+namespace
+{
+    std::string jsonDomainArray(const std::vector<std::string>& domains)
+    {
+        std::ostringstream out;
+        out << "[";
+
+        for (std::size_t i = 0; i < domains.size(); ++i)
+        {
+            if (i > 0)
+            {
+                out << ",";
+            }
+
+            out << "\"" << domains[i] << "\"";
+        }
+
+        out << "]";
+        return out.str();
+    }
+
+    uint64_t maxChangeId(
+        uint64_t channels,
+        uint64_t recordings,
+        uint64_t timers,
+        uint64_t events)
+    {
+        return std::max(std::max(channels, recordings), std::max(timers, events));
+    }
+
+    bool pathMatchesEventStream(const std::string& path)
+    {
+        return path == "/eventstream" || path == "/eventstream/";
+    }
+}
+
+EventsStreamThread::EventsStreamThread()
+    : active(false),
+      serverFd(-1),
+      listenPort(0)
+{
+}
+
+EventsStreamThread::~EventsStreamThread()
+{
+    Stop();
+}
+
+void EventsStreamThread::Initialize(const std::string& ip, unsigned short port)
+{
+    SetDescription("Restfulapi EventStreamThread");
+
+    listenIp = ip;
+    listenPort = port;
+}
+
+void EventsStreamThread::Stop()
+{
+    active.store(false);
+
+    const int fd = serverFd.exchange(-1);
+    if (fd >= 0)
+    {
+        shutdown(fd, SHUT_RDWR);
+        close(fd);
+    }
+
+    Cancel(1);
+}
+
+void EventsStreamThread::Action(void)
+{
+    active.store(true);
+
+    if (!createServerSocket())
+    {
+        active.store(false);
+        return;
+    }
+
+    isyslog(
+        "restfulapi: eventstream listening on %s:%u",
+        listenIp.c_str(),
+        static_cast<unsigned int>(listenPort));
+
+    while (active.load())
+    {
+        const int fd = serverFd.load();
+        if (fd < 0)
+        {
+            break;
+        }
+
+        fd_set readSet;
+        FD_ZERO(&readSet);
+        FD_SET(fd, &readSet);
+
+        timeval timeout;
+        timeout.tv_sec = 1;
+        timeout.tv_usec = 0;
+
+        const int result = select(fd + 1, &readSet, NULL, NULL, &timeout);
+
+        if (!active.load())
+        {
+            break;
+        }
+
+        if (result < 0)
+        {
+            if (errno == EINTR)
+            {
+                continue;
+            }
+
+            esyslog("restfulapi: eventstream select failed: %s", strerror(errno));
+            break;
+        }
+
+        if (result == 0)
+        {
+            continue;
+        }
+
+        sockaddr_in clientAddress;
+        socklen_t clientLength = sizeof(clientAddress);
+        const int clientFd = accept(fd, reinterpret_cast<sockaddr*>(&clientAddress), &clientLength);
+
+        if (clientFd < 0)
+        {
+            if (active.load())
+            {
+                esyslog("restfulapi: eventstream accept failed: %s", strerror(errno));
+            }
+            continue;
+        }
+
+        handleClient(clientFd);
+        close(clientFd);
+    }
+
+    const int fd = serverFd.exchange(-1);
+    if (fd >= 0)
+    {
+        close(fd);
+    }
+
+    isyslog("restfulapi: eventstream stopped");
+}
+
+bool EventsStreamThread::createServerSocket()
+{
+    const int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0)
+    {
+        esyslog("restfulapi: eventstream socket failed: %s", strerror(errno));
+        return false;
+    }
+
+    int reuse = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+    sockaddr_in address;
+    memset(&address, 0, sizeof(address));
+    address.sin_family = AF_INET;
+    address.sin_port = htons(listenPort);
+
+    if (listenIp.empty() || listenIp == "0.0.0.0")
+    {
+        address.sin_addr.s_addr = htonl(INADDR_ANY);
+    }
+    else if (inet_pton(AF_INET, listenIp.c_str(), &address.sin_addr) != 1)
+    {
+        esyslog("restfulapi: eventstream invalid listen ip: %s", listenIp.c_str());
+        close(fd);
+        return false;
+    }
+
+    if (bind(fd, reinterpret_cast<sockaddr*>(&address), sizeof(address)) < 0)
+    {
+        esyslog(
+            "restfulapi: eventstream bind failed on %s:%u: %s",
+            listenIp.c_str(),
+            static_cast<unsigned int>(listenPort),
+            strerror(errno));
+        close(fd);
+        return false;
+    }
+
+    if (listen(fd, 4) < 0)
+    {
+        esyslog("restfulapi: eventstream listen failed: %s", strerror(errno));
+        close(fd);
+        return false;
+    }
+
+    serverFd.store(fd);
+    return true;
+}
+
+void EventsStreamThread::handleClient(int clientFd)
+{
+    std::string requestData;
+    if (!readHttpRequest(clientFd, requestData))
+    {
+        return;
+    }
+
+    std::istringstream requestStream(requestData);
+    std::string method;
+    std::string path;
+    std::string protocol;
+
+    requestStream >> method >> path >> protocol;
+
+    if (method == "OPTIONS")
+    {
+        sendOptionsResponse(clientFd);
+        return;
+    }
+
+    if (method != "GET")
+    {
+        sendMethodNotAllowedResponse(clientFd);
+        return;
+    }
+
+    if (!pathMatchesEventStream(path))
+    {
+        sendNotFoundResponse(clientFd);
+        return;
+    }
+
+    isyslog("restfulapi: eventstream client connected");
+
+    if (!sendStreamHeaders(clientFd))
+    {
+        return;
+    }
+
+    uint64_t lastChannels = StateChangeTracker::LastChannelsUpdate();
+    uint64_t lastRecordings = StateChangeTracker::LastRecordingsUpdate();
+    uint64_t lastTimers = StateChangeTracker::LastTimersUpdate();
+    uint64_t lastEvents = StateChangeTracker::LastEventsUpdate();
+
+    if (!sendHello(clientFd))
+    {
+        return;
+    }
+
+    int heartbeatTicks = 0;
+
+    while (active.load())
+    {
+        for (int i = 0; i < 10 && active.load(); ++i)
+        {
+            usleep(100000);
+        }
+
+        if (!active.load())
+        {
+            break;
+        }
+
+        const uint64_t currentChannels = StateChangeTracker::LastChannelsUpdate();
+        const uint64_t currentRecordings = StateChangeTracker::LastRecordingsUpdate();
+        const uint64_t currentTimers = StateChangeTracker::LastTimersUpdate();
+        const uint64_t currentEvents = StateChangeTracker::LastEventsUpdate();
+
+        std::vector<std::string> domains;
+
+        if (currentChannels != lastChannels)
+        {
+            domains.push_back("channels");
+            lastChannels = currentChannels;
+        }
+
+        if (currentRecordings != lastRecordings)
+        {
+            domains.push_back("recordings");
+            lastRecordings = currentRecordings;
+        }
+
+        if (currentTimers != lastTimers)
+        {
+            domains.push_back("timers");
+            lastTimers = currentTimers;
+        }
+
+        if (currentEvents != lastEvents)
+        {
+            domains.push_back("events");
+            lastEvents = currentEvents;
+        }
+
+        if (!domains.empty())
+        {
+            heartbeatTicks = 0;
+
+            if (!sendChange(
+                    clientFd,
+                    maxChangeId(currentChannels, currentRecordings, currentTimers, currentEvents),
+                    domains))
+            {
+                break;
+            }
+
+            continue;
+        }
+
+        ++heartbeatTicks;
+        if (heartbeatTicks >= 5)
+        {
+            heartbeatTicks = 0;
+
+            if (!sendHeartbeat(clientFd))
+            {
+                break;
+            }
+        }
+    }
+
+    isyslog("restfulapi: eventstream client disconnected");
+}
+
+bool EventsStreamThread::readHttpRequest(int clientFd, std::string& requestData)
+{
+    timeval timeout;
+    timeout.tv_sec = 3;
+    timeout.tv_usec = 0;
+
+    setsockopt(clientFd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+
+    char buffer[1024];
+
+    while (requestData.size() < 8192)
+    {
+        const ssize_t received = recv(clientFd, buffer, sizeof(buffer), 0);
+
+        if (received < 0)
+        {
+            if (errno == EINTR)
+            {
+                continue;
+            }
+
+            return !requestData.empty();
+        }
+
+        if (received == 0)
+        {
+            return !requestData.empty();
+        }
+
+        requestData.append(buffer, static_cast<std::size_t>(received));
+
+        if (requestData.find("\r\n\r\n") != std::string::npos ||
+            requestData.find("\n\n") != std::string::npos)
+        {
+            return true;
+        }
+    }
+
+    return true;
+}
+
+void EventsStreamThread::sendOptionsResponse(int clientFd)
+{
+    sendAll(
+        clientFd,
+        "HTTP/1.1 200 OK\r\n"
+        "Access-Control-Allow-Origin: *\r\n"
+        "Access-Control-Allow-Methods: GET, OPTIONS\r\n"
+        "Access-Control-Allow-Headers: accept, authorization\r\n"
+        "Content-Length: 0\r\n"
+        "Connection: close\r\n"
+        "\r\n");
+}
+
+void EventsStreamThread::sendNotFoundResponse(int clientFd)
+{
+    sendAll(
+        clientFd,
+        "HTTP/1.1 404 Not Found\r\n"
+        "Access-Control-Allow-Origin: *\r\n"
+        "Content-Length: 0\r\n"
+        "Connection: close\r\n"
+        "\r\n");
+}
+
+void EventsStreamThread::sendMethodNotAllowedResponse(int clientFd)
+{
+    sendAll(
+        clientFd,
+        "HTTP/1.1 405 Method Not Allowed\r\n"
+        "Access-Control-Allow-Origin: *\r\n"
+        "Allow: GET, OPTIONS\r\n"
+        "Content-Length: 0\r\n"
+        "Connection: close\r\n"
+        "\r\n");
+}
+
+bool EventsStreamThread::sendAll(int clientFd, const std::string& data)
+{
+    const char* cursor = data.c_str();
+    std::size_t remaining = data.size();
+
+    while (remaining > 0)
+    {
+        const ssize_t sent = send(clientFd, cursor, remaining, MSG_NOSIGNAL);
+
+        if (sent <= 0)
+        {
+            return false;
+        }
+
+        cursor += sent;
+        remaining -= static_cast<std::size_t>(sent);
+    }
+
+    return true;
+}
+
+bool EventsStreamThread::sendStreamHeaders(int clientFd)
+{
+    return sendAll(
+        clientFd,
+        "HTTP/1.1 200 OK\r\n"
+        "Access-Control-Allow-Origin: *\r\n"
+        "Access-Control-Allow-Methods: GET, OPTIONS\r\n"
+        "Access-Control-Allow-Headers: accept, authorization\r\n"
+        "Content-Type: text/event-stream; charset=utf-8\r\n"
+        "Cache-Control: no-cache\r\n"
+        "Connection: keep-alive\r\n"
+        "X-Accel-Buffering: no\r\n"
+        "\r\n");
+}
+
+bool EventsStreamThread::sendHello(int clientFd)
+{
+    std::ostringstream out;
+
+    out
+        << "event: hello\n"
+        << "data: {\"source\":\"restfulapi\",\"bootID\":\""
+        << StateChangeTracker::bootID
+        << "\",\"domains\":[]}\n"
+        << "\n";
+
+    return sendAll(clientFd, out.str());
+}
+
+bool EventsStreamThread::sendHeartbeat(int clientFd)
+{
+    return sendAll(clientFd, ": heartbeat\n\n");
+}
+
+bool EventsStreamThread::sendChange(
+    int clientFd,
+    uint64_t eventId,
+    const std::vector<std::string>& domains)
+{
+    std::ostringstream out;
+
+    out
+        << "event: vdr-change\n"
+        << "id: " << eventId << "\n"
+        << "data: {\"source\":\"restfulapi\",\"domains\":"
+        << jsonDomainArray(domains)
+        << "}\n"
+        << "\n";
+
+    return sendAll(clientFd, out.str());
+}

--- a/eventsstreamthread.h
+++ b/eventsstreamthread.h
@@ -1,0 +1,44 @@
+#ifndef __EVENTSSTREAMTHREAD_H
+#define __EVENTSSTREAMTHREAD_H
+
+#include <stdint.h>
+
+#include <atomic>
+#include <string>
+#include <vector>
+
+#include <vdr/thread.h>
+
+class EventsStreamThread : public cThread
+{
+private:
+    std::atomic<bool> active;
+    std::atomic<int> serverFd;
+    std::string listenIp;
+    unsigned short listenPort;
+
+    void Action(void) override;
+
+    bool createServerSocket();
+    void handleClient(int clientFd);
+    bool readHttpRequest(int clientFd, std::string& requestData);
+
+    void sendOptionsResponse(int clientFd);
+    void sendNotFoundResponse(int clientFd);
+    void sendMethodNotAllowedResponse(int clientFd);
+    bool sendAll(int clientFd, const std::string& data);
+
+    bool sendStreamHeaders(int clientFd);
+    bool sendHello(int clientFd);
+    bool sendHeartbeat(int clientFd);
+    bool sendChange(int clientFd, uint64_t eventId, const std::vector<std::string>& domains);
+
+public:
+    EventsStreamThread();
+    ~EventsStreamThread();
+
+    void Initialize(const std::string& ip, unsigned short port);
+    void Stop();
+};
+
+#endif

--- a/serverthread.cpp
+++ b/serverthread.cpp
@@ -9,15 +9,20 @@ void cServerThread::Initialize()
   listenIp = Settings::get()->Ip();
   listenPort = Settings::get()->Port();
 
+  eventsStreamThread.Initialize(listenIp, static_cast<unsigned short int>(listenPort + 1));
+  eventsStreamThread.Start();
+
   isyslog("create server");
   server = new cxxtools::http::Server(loop, listenIp, listenPort);
 
   services = RestfulServices::get();
-}
+
+  }
 
 void cServerThread::Stop() {
+  eventsStreamThread.Stop();
   active = false;
-  loop.exit();
+    loop.exit();
   int now = time(NULL);
   esyslog("restfulapi: will end server thread: /%i/", now);
   usleep(100000);//100ms//sleep(1);

--- a/serverthread.cpp
+++ b/serverthread.cpp
@@ -2,8 +2,7 @@
 
 void cServerThread::Initialize()
 {
-
-	SetDescription("Restfulapi Serverthread");
+  SetDescription("Restfulapi Serverthread");
   active = false; 
 
   listenIp = Settings::get()->Ip();
@@ -16,13 +15,12 @@ void cServerThread::Initialize()
   server = new cxxtools::http::Server(loop, listenIp, listenPort);
 
   services = RestfulServices::get();
-
-  }
+}
 
 void cServerThread::Stop() {
   eventsStreamThread.Stop();
   active = false;
-    loop.exit();
+  loop.exit();
   int now = time(NULL);
   esyslog("restfulapi: will end server thread: /%i/", now);
   usleep(100000);//100ms//sleep(1);
@@ -132,7 +130,6 @@ void cServerThread::addWebappService(string name) {
   int i=0;
 
   for (; it != end; it++) {
-
       if (restfulservices[i]->Path() == path) {
 	  occupied = true;
       }

--- a/serverthread.h
+++ b/serverthread.h
@@ -19,6 +19,7 @@
 #include "remote.h"
 #include "timers.h"
 #include "changestate.h"
+#include "eventsstreamthread.h"
 #include "osd.h"
 #include "searchtimers.h"
 #include "epgsearch.h"
@@ -36,6 +37,7 @@ private:
     unsigned short int listenPort;
     cxxtools::EventLoop loop;
     cxxtools::http::Server *server;
+    EventsStreamThread eventsStreamThread;
     void Action(void);
     WebappService webappService;
     RestfulServices* services;


### PR DESCRIPTION
## Summary

This pull request adds a Server-Sent Events stream for lightweight VDR state change notifications.

The new event stream exposes VDR state changes as invalidation hints so external clients can react without repeatedly polling all REST resources.

Endpoint:

    GET /eventstream

The stream listens on the RESTfulAPI port plus one. For example, if RESTfulAPI listens on port 8002, the event stream listens on port 8003.

## Motivation

The plugin already tracks VDR state changes internally through StateChangeTracker, including:

- channels
- recordings
- timers
- events

The existing /change-state endpoint exposes these values as a snapshot, but clients still have to poll it.

For modern web frontends and orchestration services, SSE is a better fit:

- one lightweight long-lived connection
- low latency
- no full polling loop required
- clients refresh only the affected REST resources

## Design

The implementation adds a dedicated EventsStreamThread.

It intentionally does not use a normal cxxtools REST responder for the actual stream. A prototype responder was tested, but cxxtools generated a fixed Content-Length response. That means the response was buffered and was not a true continuous SSE stream.

Real SSE must keep the connection open and must not send a fixed Content-Length.

The dedicated thread writes the HTTP response manually and keeps the socket open.

## Event format

Initial hello event:

    event: hello
    data: {"source":"restfulapi","bootID":"...","domains":[]}

Change event:

    event: vdr-change
    id: 123456789
    data: {"source":"restfulapi","domains":["timers"]}

Heartbeat:

    : heartbeat

## Client behavior

Clients should treat SSE events as invalidation hints.

The stream does not duplicate full REST payloads. Instead, clients should reload the affected REST resource:

- domains: ["timers"] -> reload timers
- domains: ["recordings"] -> reload recordings
- domains: ["channels"] -> reload channels
- domains: ["events"] -> reload the relevant EPG query

This keeps the stream small and avoids pushing large payloads such as full EPG data.

## Runtime validation

Tested locally with VDR and RESTfulAPI.

The stream listens on port 8003 when RESTfulAPI runs on 8002.

Command:

    curl -N http://127.0.0.1:8003/eventstream

Observed output:

    event: hello
    data: {"source":"restfulapi","bootID":"...","domains":[]}

    : heartbeat

    event: vdr-change
    id: ...
    data: {"source":"restfulapi","domains":["timers"]}

    event: vdr-change
    id: ...
    data: {"source":"restfulapi","domains":["recordings"]}

The response was a real open stream without Content-Length.

## Notes

The stream uses /eventstream instead of /events/stream to avoid conflicting with the existing broad /events service path matching.
