### PR TITLE
Add safe native recording trash workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o recordingvalidate.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o recordingvalidate.o recordingtrashexecutor.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o recordingvalidate.o recordingtrashexecutor.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o recordingvalidate.o recordingtrashexecutor.o recordingtrash.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n
@@ -55,8 +55,8 @@ $(DEPFILE): Makefile
 
 PODIR     = po
 I18Npo    = $(wildcard $(PODIR)/*.po)
-I18Nmo    = $(addsuffix .mo, $(foreach file, $(I18Npo), $(basename $(file))))
-I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/, $(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo, $(notdir $(foreach file, $(I18Npo), $(basename $(file))))))
+I18Nmo    = $(addsuffix .mo, $(foreach file,$(I18Npo),$(basename $(file))))
+I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/,$(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo,$(notdir $(foreach file,$(I18Npo),$(basename $(file))))))
 I18Npot   = $(PODIR)/$(PLUGIN).pot
 
 %.mo: %.po

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,6 @@ dist: $(I18Npo) clean
 clean:
 	@-rm -f $(PODIR)/*.mo $(PODIR)/*.pot
 	@-rm -f $(OBJS) $(DEPFILE) *.so *.tgz core* *~ ._*
-
+	
 archive:
 	git archive --format=tar.gz --prefix=vdr-plugin-restfulapi-${VERSION}/ --output=../vdr-plugin-restfulapi-${VERSION}.tar.gz master

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n
@@ -55,8 +55,8 @@ $(DEPFILE): Makefile
 
 PODIR     = po
 I18Npo    = $(wildcard $(PODIR)/*.po)
-I18Nmo    = $(addsuffix .mo, $(foreach file, $(I18Npo), $(basename $(file))))
-I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/, $(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo, $(notdir $(foreach file, $(I18Npo), $(basename $(file))))))
+I18Nmo    = $(addsuffix .mo, $(foreach file,$(I18Npo),$(basename $(file))))
+I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/,$(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo,$(notdir $(foreach file,$(I18Npo),$(basename $(file))))))
 I18Npot   = $(PODIR)/$(PLUGIN).pot
 
 %.mo: %.po
@@ -87,19 +87,3 @@ install-cfg: $(CFGS)
 	install -D $^ $(DESTDIR)$(PLGCONFDIR)/$^
 
 install: install-lib install-i18n install-cfg
-
-dist: $(I18Npo) clean
-	@-rm -rf $(TMPDIR)/$(ARCHIVE)
-	@mkdir $(TMPDIR)/$(ARCHIVE)
-	@cp -a * $(TMPDIR)/$(ARCHIVE)
-	@-rm -rf $(TMPDIR)/$(ARCHIVE)/debian
-	@tar czf $(PACKAGE).tgz -C $(TMPDIR) $(ARCHIVE)
-	@-rm -rf $(TMPDIR)/$(ARCHIVE)
-	@echo Distribution package created as $(PACKAGE).tgz
-
-clean:
-	@-rm -f $(PODIR)/*.mo $(PODIR)/*.pot
-	@-rm -f $(OBJS) $(DEPFILE) *.so *.tgz core* *~ ._*
-	
-archive:
-	git archive --format=tar.gz --prefix=vdr-plugin-restfulapi-${VERSION}/ --output=../vdr-plugin-restfulapi-${VERSION}.tar.gz master

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o recordingvalidate.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ $(DEPFILE): Makefile
 
 PODIR     = po
 I18Npo    = $(wildcard $(PODIR)/*.po)
-I18Nmo    = $(addsuffix .mo, $(foreach file,$(I18Npo),$(basename $(file))))
-I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/,$(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo,$(notdir $(foreach file,$(I18Npo),$(basename $(file))))))
+I18Nmo    = $(addsuffix .mo, $(foreach file, $(I18Npo), $(basename $(file))))
+I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/, $(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo, $(notdir $(foreach file, $(I18Npo), $(basename $(file))))))
 I18Npot   = $(PODIR)/$(PLUGIN).pot
 
 %.mo: %.po

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ $(DEPFILE): Makefile
 
 PODIR     = po
 I18Npo    = $(wildcard $(PODIR)/*.po)
-I18Nmo    = $(addsuffix .mo, $(foreach file,$(I18Npo),$(basename $(file))))
-I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/,$(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo,$(notdir $(foreach file,$(I18Npo),$(basename $(file))))))
+I18Nmo    = $(addsuffix .mo, $(foreach file, $(I18Npo), $(basename $(file))))
+I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/, $(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo, $(notdir $(foreach file, $(I18Npo), $(basename $(file))))))
 I18Npot   = $(PODIR)/$(PLUGIN).pot
 
 %.mo: %.po
@@ -87,3 +87,19 @@ install-cfg: $(CFGS)
 	install -D $^ $(DESTDIR)$(PLGCONFDIR)/$^
 
 install: install-lib install-i18n install-cfg
+
+dist: $(I18Npo) clean
+	@-rm -rf $(TMPDIR)/$(ARCHIVE)
+	@mkdir $(TMPDIR)/$(ARCHIVE)
+	@cp -a * $(TMPDIR)/$(ARCHIVE)
+	@-rm -rf $(TMPDIR)/$(ARCHIVE)/debian
+	@tar czf $(PACKAGE).tgz -C $(TMPDIR) $(ARCHIVE)
+	@-rm -rf $(TMPDIR)/$(ARCHIVE)
+	@echo Distribution package created as $(PACKAGE).tgz
+
+clean:
+	@-rm -f $(PODIR)/*.mo $(PODIR)/*.pot
+	@-rm -f $(OBJS) $(DEPFILE) *.so *.tgz core* *~ ._*
+
+archive:
+	git archive --format=tar.gz --prefix=vdr-plugin-restfulapi-${VERSION}/ --output=../vdr-plugin-restfulapi-${VERSION}.tar.gz master

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n

--- a/RECORDING_TRASH_API.md
+++ b/RECORDING_TRASH_API.md
@@ -1,0 +1,193 @@
+# Safe Native Recording Trash API
+
+This document describes the recording trash workflow implemented by the RESTfulAPI plugin.
+
+The implementation deliberately follows native VDR behavior. It does not introduce a separate long-lived trash store and it does not automatically stop playback, stop recordings, delete timers, or cancel VDR handler operations.
+
+## Native VDR semantics
+
+A successful trash operation normally changes the recording directory from:
+
+```text
+/path/to/recording.rec
+```
+
+to:
+
+```text
+/path/to/recording.del
+```
+
+VDR may permanently remove the `.del` directory later during its regular cleanup. Therefore, `already-trashed` is only a temporary idempotent state while the native `.del` directory still exists. Once both `.rec` and `.del` are gone, the recording is no longer available.
+
+## Workflow
+
+Recording trash uses a three-step optimistic-locking workflow:
+
+1. Preview the operation and obtain state fingerprints.
+2. Optionally validate that the fingerprints are still current.
+3. Execute the operation with the confirmed fingerprints.
+
+Preview and validation are read-only. They do not modify the recording, timers, playback state, or VDR recording lists.
+
+## Preview
+
+```http
+POST /recordings/trash/preview.json
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+  "file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec"
+}
+```
+
+Executable response:
+
+```json
+{
+  "executable": true,
+  "recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "constraints": [],
+  "blockers": [],
+  "warnings": [],
+  "steps": [
+    "trash-recording",
+    "refresh-recordings",
+    "notify-change"
+  ],
+  "revision_recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "revision_recordings_state": 123456789,
+  "revision_timers_state": 987654321
+}
+```
+
+Blocked response example:
+
+```json
+{
+  "executable": false,
+  "recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "constraints": [
+    "local-timer-active"
+  ],
+  "blockers": [
+    "local-timer-active"
+  ],
+  "warnings": [],
+  "steps": [],
+  "revision_recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "revision_recordings_state": 123456789,
+  "revision_timers_state": 987654321
+}
+```
+
+## Validate
+
+```http
+POST /recordings/trash/validate.json
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+  "file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "revision_recordings_state": "123456789",
+  "revision_timers_state": "987654321"
+}
+```
+
+Validation status values:
+
+- `ready`: the recording is still executable with this revision.
+- `conflict`: recording, replay, handler, or timer state changed after preview.
+- `blocked`: the current state or policy does not allow execution.
+
+## Execute
+
+```http
+POST /recordings/trash.json
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+  "file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "revision_recordings_state": "123456789",
+  "revision_timers_state": "987654321"
+}
+```
+
+Successful response:
+
+```json
+{
+  "status": "trashed",
+  "recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "deleted_recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.del",
+  "message": "Recording moved to the VDR trash."
+}
+```
+
+Immediate idempotent retry while `.del` still exists:
+
+```json
+{
+  "status": "already-trashed",
+  "recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "deleted_recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.del",
+  "message": "Recording is already present in the VDR trash."
+}
+```
+
+## Protected states
+
+The operation is blocked when safety cannot be established or VDR is actively using the recording:
+
+- `replay-active`
+- `recording-handler-busy`
+- `local-timer-active`
+- `remote-timer-active`
+- `unknown-recording-handler-state`
+- `unknown-local-timer-state`
+- `unknown-remote-timer-state`
+- `unknown-search-timer-state`
+
+The execution endpoint does not automatically resolve these states.
+
+## HTTP status codes
+
+| Status | Meaning |
+|---|---|
+| `200` | The recording was trashed or is already in VDR's native deleted state. |
+| `400` | The recording file or required revision values are missing or invalid. |
+| `404` | The recording is no longer present. |
+| `409` | Recording or timer state changed after preview. |
+| `423` | The operation is blocked by the current VDR state or policy. |
+| `500` | The native VDR mutation or postcondition verification failed. |
+| `501` | The requested HTTP method is not supported. |
+
+## Verified integration behavior
+
+The following cases were verified against a running VDR installation:
+
+- normal completed recording: `200 trashed`
+- immediate identical retry: `200 already-trashed`
+- active local recording: `423`, recording and timer remain active
+- active replay: `423`, recording remains present and replay is not stopped
+- stale revision: `409`
+- missing revision: `400`
+- unsupported method: `501`
+- preview: no filesystem mutation
+- successful execution: `.rec` becomes `.del` and VDR remains active
+
+## Design boundary
+
+This API models native VDR deletion. It is not a separate VDR-Suite recycle bin and does not guarantee a restore window. VDR controls when native `.del` recordings are permanently cleaned up.

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -32,11 +32,26 @@ bool VdrRecordingReplayLookup::isReplaying(const std::string& recordingFile) con
   return nowReplaying && std::strcmp(nowReplaying, recordingFile.c_str()) == 0;
 }
 
+RecordingHandlerLookupResult VdrRecordingHandlerLookup::getUsage(
+  const std::string& recordingFile) const
+{
+  RecordingHandlerLookupResult result;
+
+  if (recordingFile.empty())
+    return result;
+
+  result.known = true;
+  result.busy = RecordingsHandler.GetUsage(recordingFile.c_str()) != ruNone;
+  return result;
+}
+
 RecordingTrashAnalyzer::RecordingTrashAnalyzer(
   const IRecordingLookup& recordingLookup,
-  const IRecordingReplayLookup& replayLookup)
+  const IRecordingReplayLookup& replayLookup,
+  const IRecordingHandlerLookup& recordingHandlerLookup)
   : recordingLookup(recordingLookup),
-    replayLookup(replayLookup)
+    replayLookup(replayLookup),
+    recordingHandlerLookup(recordingHandlerLookup)
 {
 }
 
@@ -61,7 +76,14 @@ RecordingMutationAnalysis RecordingTrashAnalyzer::analyze(
   if (replayLookup.isReplaying(recording.recordingFile))
     analysis.constraints.push_back(RecordingConstraint::ReplayActive);
 
-  analysis.constraints.push_back(RecordingConstraint::UnknownRecordingHandlerState);
+  const RecordingHandlerLookupResult handlerUsage =
+    recordingHandlerLookup.getUsage(recording.recordingFile);
+
+  if (!handlerUsage.known)
+    analysis.constraints.push_back(RecordingConstraint::UnknownRecordingHandlerState);
+  else if (handlerUsage.busy)
+    analysis.constraints.push_back(RecordingConstraint::RecordingHandlerBusy);
+
   analysis.constraints.push_back(RecordingConstraint::UnknownTimerState);
   analysis.constraints.push_back(RecordingConstraint::UnknownSearchTimerState);
 

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -6,6 +6,70 @@
 #include <vdr/menu.h>
 #include <vdr/recording.h>
 
+namespace {
+
+bool parsePositiveInteger(const std::string& value, int& result)
+{
+  try {
+    std::size_t parsed = 0;
+    const long number = std::stol(value, &parsed, 10);
+    if (parsed != value.size() || number < 0 || number > std::numeric_limits<int>::max())
+      return false;
+    result = static_cast<int>(number);
+    return true;
+  }
+  catch (...) {
+    return false;
+  }
+}
+
+bool parseSearchTimerId(const char* aux, bool& present, int& searchTimerId)
+{
+  present = false;
+  searchTimerId = -1;
+
+  if (!aux || !*aux)
+    return true;
+
+  const std::string value(aux);
+  const std::string openTag = "<s-id>";
+  const std::string closeTag = "</s-id>";
+  const std::string::size_type begin = value.find(openTag);
+
+  if (begin == std::string::npos)
+    return true;
+
+  const std::string::size_type contentBegin = begin + openTag.size();
+  const std::string::size_type end = value.find(closeTag, contentBegin);
+  if (end == std::string::npos || end == contentBegin)
+    return false;
+
+  const std::string idText = value.substr(contentBegin, end - contentBegin);
+  if (!parsePositiveInteger(idText, searchTimerId))
+    return false;
+
+  present = true;
+  return true;
+}
+
+bool parseRemoteTimerId(
+  const std::string& value,
+  int& timerId,
+  std::string& remote)
+{
+  const std::string::size_type separator = value.find('@');
+  if (separator == std::string::npos || separator == 0 || separator + 1 >= value.size())
+    return false;
+
+  if (!parsePositiveInteger(value.substr(0, separator), timerId) || timerId <= 0)
+    return false;
+
+  remote = value.substr(separator + 1);
+  return !remote.empty();
+}
+
+}
+
 RecordingLookupResult VdrRecordingLookup::find(const std::string& recordingFile) const
 {
   RecordingLookupResult result;
@@ -75,24 +139,7 @@ RecordingRemoteTimerLookupResult VdrRecordingRemoteTimerLookup::findActive(
     return result;
   }
 
-  const std::string value(timerId);
-  const std::string::size_type separator = value.find('@');
-  if (separator == std::string::npos || separator == 0 || separator + 1 >= value.size())
-    return result;
-
-  try {
-    std::size_t parsed = 0;
-    const long id = std::stol(value.substr(0, separator), &parsed, 10);
-    if (parsed != separator || id <= 0 || id > std::numeric_limits<int>::max())
-      return result;
-    result.timerId = static_cast<int>(id);
-  }
-  catch (...) {
-    return result;
-  }
-
-  result.remote = value.substr(separator + 1);
-  if (result.remote.empty())
+  if (!parseRemoteTimerId(timerId, result.timerId, result.remote))
     return result;
 
   LOCK_TIMERS_READ;
@@ -105,17 +152,63 @@ RecordingRemoteTimerLookupResult VdrRecordingRemoteTimerLookup::findActive(
   return result;
 }
 
+RecordingSearchTimerLookupResult VdrRecordingSearchTimerLookup::findOrigin(
+  const std::string& recordingFile) const
+{
+  RecordingSearchTimerLookupResult result;
+
+  if (recordingFile.empty())
+    return result;
+
+  LOCK_TIMERS_READ;
+
+  const cTimer* timer = nullptr;
+  if (cRecordControl* recordControl = cRecordControls::GetRecordControl(recordingFile.c_str()))
+    timer = recordControl->Timer();
+
+  if (!timer) {
+    const cString timerIdText = GetRecordingTimerId(recordingFile.c_str());
+    const char* timerId = *timerIdText;
+
+    if (!timerId || !*timerId) {
+      result.known = true;
+      return result;
+    }
+
+    int id = 0;
+    std::string remote;
+    if (!parseRemoteTimerId(timerId, id, remote))
+      return result;
+
+    timer = Timers->GetById(id, remote.c_str());
+    if (!timer)
+      return result;
+  }
+
+  bool present = false;
+  int searchTimerId = -1;
+  if (!parseSearchTimerId(timer->Aux(), present, searchTimerId))
+    return result;
+
+  result.known = true;
+  result.searchTimerRecording = present;
+  result.searchTimerId = present ? searchTimerId : -1;
+  return result;
+}
+
 RecordingTrashAnalyzer::RecordingTrashAnalyzer(
   const IRecordingLookup& recordingLookup,
   const IRecordingReplayLookup& replayLookup,
   const IRecordingHandlerLookup& recordingHandlerLookup,
   const IRecordingLocalTimerLookup& localTimerLookup,
-  const IRecordingRemoteTimerLookup& remoteTimerLookup)
+  const IRecordingRemoteTimerLookup& remoteTimerLookup,
+  const IRecordingSearchTimerLookup& searchTimerLookup)
   : recordingLookup(recordingLookup),
     replayLookup(replayLookup),
     recordingHandlerLookup(recordingHandlerLookup),
     localTimerLookup(localTimerLookup),
-    remoteTimerLookup(remoteTimerLookup)
+    remoteTimerLookup(remoteTimerLookup),
+    searchTimerLookup(searchTimerLookup)
 {
 }
 
@@ -164,7 +257,13 @@ RecordingMutationAnalysis RecordingTrashAnalyzer::analyze(
   else if (remoteTimer.active)
     analysis.constraints.push_back(RecordingConstraint::RemoteTimerActive);
 
-  analysis.constraints.push_back(RecordingConstraint::UnknownSearchTimerState);
+  const RecordingSearchTimerLookupResult searchTimer =
+    searchTimerLookup.findOrigin(recording.recordingFile);
+
+  if (!searchTimer.known)
+    analysis.constraints.push_back(RecordingConstraint::UnknownSearchTimerState);
+  else if (searchTimer.searchTimerRecording)
+    analysis.constraints.push_back(RecordingConstraint::SearchTimerRecording);
 
   return analysis;
 }

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -45,13 +45,28 @@ RecordingHandlerLookupResult VdrRecordingHandlerLookup::getUsage(
   return result;
 }
 
+RecordingLocalTimerLookupResult VdrRecordingLocalTimerLookup::findActive(
+  const std::string& recordingFile) const
+{
+  RecordingLocalTimerLookupResult result;
+
+  if (recordingFile.empty())
+    return result;
+
+  result.known = true;
+  result.active = cRecordControls::GetRecordControl(recordingFile.c_str()) != nullptr;
+  return result;
+}
+
 RecordingTrashAnalyzer::RecordingTrashAnalyzer(
   const IRecordingLookup& recordingLookup,
   const IRecordingReplayLookup& replayLookup,
-  const IRecordingHandlerLookup& recordingHandlerLookup)
+  const IRecordingHandlerLookup& recordingHandlerLookup,
+  const IRecordingLocalTimerLookup& localTimerLookup)
   : recordingLookup(recordingLookup),
     replayLookup(replayLookup),
-    recordingHandlerLookup(recordingHandlerLookup)
+    recordingHandlerLookup(recordingHandlerLookup),
+    localTimerLookup(localTimerLookup)
 {
 }
 
@@ -84,7 +99,15 @@ RecordingMutationAnalysis RecordingTrashAnalyzer::analyze(
   else if (handlerUsage.busy)
     analysis.constraints.push_back(RecordingConstraint::RecordingHandlerBusy);
 
-  analysis.constraints.push_back(RecordingConstraint::UnknownTimerState);
+  const RecordingLocalTimerLookupResult localTimer =
+    localTimerLookup.findActive(recording.recordingFile);
+
+  if (!localTimer.known)
+    analysis.constraints.push_back(RecordingConstraint::UnknownLocalTimerState);
+  else if (localTimer.active)
+    analysis.constraints.push_back(RecordingConstraint::LocalTimerActive);
+
+  analysis.constraints.push_back(RecordingConstraint::UnknownRemoteTimerState);
   analysis.constraints.push_back(RecordingConstraint::UnknownSearchTimerState);
 
   return analysis;

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -1,7 +1,10 @@
 #include "recordinganalysis.h"
 
+#include <cstdint>
 #include <cstring>
 #include <limits>
+#include <sstream>
+#include <sys/stat.h>
 
 #include <vdr/menu.h>
 #include <vdr/recording.h>
@@ -66,6 +69,59 @@ bool parseRemoteTimerId(
 
   remote = value.substr(separator + 1);
   return !remote.empty();
+}
+
+long long fingerprint(const std::string& value)
+{
+  std::uint64_t hash = 1469598103934665603ULL;
+  for (unsigned char character : value) {
+    hash ^= character;
+    hash *= 1099511628211ULL;
+  }
+  return static_cast<long long>(hash & 0x7FFFFFFFFFFFFFFFULL);
+}
+
+long long recordingFingerprint(const std::string& recordingFile, bool found)
+{
+  std::ostringstream state;
+  state << recordingFile << '|';
+  state << (found ? "found" : "missing");
+
+  struct stat fileState;
+  if (found && stat(recordingFile.c_str(), &fileState) == 0) {
+    state << '|' << static_cast<unsigned long long>(fileState.st_dev);
+    state << '|' << static_cast<unsigned long long>(fileState.st_ino);
+    state << '|' << static_cast<long long>(fileState.st_mtime);
+    state << '|' << static_cast<long long>(fileState.st_ctime);
+  }
+  else if (found) {
+    state << "|stat-unavailable";
+  }
+
+  return fingerprint(state.str());
+}
+
+long long timerFingerprint(
+  bool replaying,
+  const RecordingHandlerLookupResult& handlerUsage,
+  const RecordingLocalTimerLookupResult& localTimer,
+  const RecordingRemoteTimerLookupResult& remoteTimer,
+  const RecordingSearchTimerLookupResult& searchTimer)
+{
+  std::ostringstream state;
+  state << "replay=" << replaying;
+  state << "|handler-known=" << handlerUsage.known;
+  state << "|handler-busy=" << handlerUsage.busy;
+  state << "|local-known=" << localTimer.known;
+  state << "|local-active=" << localTimer.active;
+  state << "|remote-known=" << remoteTimer.known;
+  state << "|remote-active=" << remoteTimer.active;
+  state << "|remote-id=" << remoteTimer.timerId;
+  state << "|remote=" << remoteTimer.remote;
+  state << "|search-known=" << searchTimer.known;
+  state << "|search-recording=" << searchTimer.searchTimerRecording;
+  state << "|search-id=" << searchTimer.searchTimerId;
+  return fingerprint(state.str());
 }
 
 }
@@ -221,6 +277,7 @@ RecordingMutationAnalysis RecordingTrashAnalyzer::analyze(
   analysis.revision.recordingFile = recordingFile;
 
   const RecordingLookupResult recording = recordingLookup.find(recordingFile);
+  analysis.revision.recordingsState = recordingFingerprint(recordingFile, recording.found);
 
   if (!recording.found) {
     analysis.constraints.push_back(RecordingConstraint::RecordingMissing);
@@ -229,8 +286,10 @@ RecordingMutationAnalysis RecordingTrashAnalyzer::analyze(
 
   analysis.recordingFile = recording.recordingFile;
   analysis.revision.recordingFile = recording.recordingFile;
+  analysis.revision.recordingsState = recordingFingerprint(recording.recordingFile, true);
 
-  if (replayLookup.isReplaying(recording.recordingFile))
+  const bool replaying = replayLookup.isReplaying(recording.recordingFile);
+  if (replaying)
     analysis.constraints.push_back(RecordingConstraint::ReplayActive);
 
   const RecordingHandlerLookupResult handlerUsage =
@@ -264,6 +323,13 @@ RecordingMutationAnalysis RecordingTrashAnalyzer::analyze(
     analysis.constraints.push_back(RecordingConstraint::UnknownSearchTimerState);
   else if (searchTimer.searchTimerRecording)
     analysis.constraints.push_back(RecordingConstraint::SearchTimerRecording);
+
+  analysis.revision.timersState = timerFingerprint(
+    replaying,
+    handlerUsage,
+    localTimer,
+    remoteTimer,
+    searchTimer);
 
   return analysis;
 }

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -1,0 +1,69 @@
+#include "recordinganalysis.h"
+
+#include <cstring>
+
+#include <vdr/menu.h>
+#include <vdr/recording.h>
+
+RecordingLookupResult VdrRecordingLookup::find(const std::string& recordingFile) const
+{
+  RecordingLookupResult result;
+
+  if (recordingFile.empty())
+    return result;
+
+  LOCK_RECORDINGS_READ;
+  const cRecording* recording = Recordings->GetByName(recordingFile.c_str());
+
+  if (!recording)
+    return result;
+
+  result.found = true;
+  result.recordingFile = recording->FileName();
+  return result;
+}
+
+bool VdrRecordingReplayLookup::isReplaying(const std::string& recordingFile) const
+{
+  if (recordingFile.empty())
+    return false;
+
+  const char* nowReplaying = cReplayControl::NowReplaying();
+  return nowReplaying && std::strcmp(nowReplaying, recordingFile.c_str()) == 0;
+}
+
+RecordingTrashAnalyzer::RecordingTrashAnalyzer(
+  const IRecordingLookup& recordingLookup,
+  const IRecordingReplayLookup& replayLookup)
+  : recordingLookup(recordingLookup),
+    replayLookup(replayLookup)
+{
+}
+
+RecordingMutationAnalysis RecordingTrashAnalyzer::analyze(
+  const std::string& recordingFile) const
+{
+  RecordingMutationAnalysis analysis;
+  analysis.type = RecordingMutationType::Trash;
+  analysis.recordingFile = recordingFile;
+  analysis.revision.recordingFile = recordingFile;
+
+  const RecordingLookupResult recording = recordingLookup.find(recordingFile);
+
+  if (!recording.found) {
+    analysis.constraints.push_back(RecordingConstraint::RecordingMissing);
+    return analysis;
+  }
+
+  analysis.recordingFile = recording.recordingFile;
+  analysis.revision.recordingFile = recording.recordingFile;
+
+  if (replayLookup.isReplaying(recording.recordingFile))
+    analysis.constraints.push_back(RecordingConstraint::ReplayActive);
+
+  analysis.constraints.push_back(RecordingConstraint::UnknownRecordingHandlerState);
+  analysis.constraints.push_back(RecordingConstraint::UnknownTimerState);
+  analysis.constraints.push_back(RecordingConstraint::UnknownSearchTimerState);
+
+  return analysis;
+}

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -204,7 +204,11 @@ RecordingRemoteTimerLookupResult VdrRecordingRemoteTimerLookup::findActive(
   }
 
   LOCK_TIMERS_READ;
-  const cTimer* timer = Timers->GetById(result.timerId, result.remote.c_str());
+
+  const cTimer* timer = Timers->GetById(result.timerId, nullptr);
+  if (!timer)
+    timer = Timers->GetById(result.timerId, result.remote.c_str());
+
   if (!timer)
     return result;
 
@@ -246,7 +250,10 @@ RecordingSearchTimerLookupResult VdrRecordingSearchTimerLookup::findOrigin(
       return result;
     }
 
-    timer = Timers->GetById(id, remote.c_str());
+    timer = Timers->GetById(id, nullptr);
+    if (!timer)
+      timer = Timers->GetById(id, remote.c_str());
+
     if (!timer)
       return result;
   }

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -205,15 +205,23 @@ RecordingRemoteTimerLookupResult VdrRecordingRemoteTimerLookup::findActive(
 
   LOCK_TIMERS_READ;
 
-  const cTimer* timer = Timers->GetById(result.timerId, nullptr);
-  if (!timer)
-    timer = Timers->GetById(result.timerId, result.remote.c_str());
+  const cTimer* localTimer = Timers->GetById(result.timerId, nullptr);
+  if (localTimer) {
+    result.known = true;
+    result.active = false;
+    result.remote.clear();
+    return result;
+  }
 
-  if (!timer)
+  const cTimer* remoteTimer =
+    Timers->GetById(result.timerId, result.remote.c_str());
+
+  if (!remoteTimer)
     return result;
 
   result.known = true;
-  result.active = timer->HasFlags(tfActive) || timer->Recording();
+  result.active =
+    remoteTimer->HasFlags(tfActive) || remoteTimer->Recording();
   return result;
 }
 

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -64,7 +64,7 @@ bool parseRemoteTimerId(
   if (separator == std::string::npos || separator == 0 || separator + 1 >= value.size())
     return false;
 
-  if (!parsePositiveInteger(value.substr(0, separator), timerId) || timerId <= 0)
+  if (!parsePositiveInteger(value.substr(0, separator), timerId))
     return false;
 
   remote = value.substr(separator + 1);
@@ -198,6 +198,11 @@ RecordingRemoteTimerLookupResult VdrRecordingRemoteTimerLookup::findActive(
   if (!parseRemoteTimerId(timerId, result.timerId, result.remote))
     return result;
 
+  if (result.timerId == 0) {
+    result.known = true;
+    return result;
+  }
+
   LOCK_TIMERS_READ;
   const cTimer* timer = Timers->GetById(result.timerId, result.remote.c_str());
   if (!timer)
@@ -235,6 +240,11 @@ RecordingSearchTimerLookupResult VdrRecordingSearchTimerLookup::findOrigin(
     std::string remote;
     if (!parseRemoteTimerId(timerId, id, remote))
       return result;
+
+    if (id == 0) {
+      result.known = true;
+      return result;
+    }
 
     timer = Timers->GetById(id, remote.c_str());
     if (!timer)

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -1,6 +1,7 @@
 #include "recordinganalysis.h"
 
 #include <cstring>
+#include <limits>
 
 #include <vdr/menu.h>
 #include <vdr/recording.h>
@@ -58,15 +59,63 @@ RecordingLocalTimerLookupResult VdrRecordingLocalTimerLookup::findActive(
   return result;
 }
 
+RecordingRemoteTimerLookupResult VdrRecordingRemoteTimerLookup::findActive(
+  const std::string& recordingFile) const
+{
+  RecordingRemoteTimerLookupResult result;
+
+  if (recordingFile.empty())
+    return result;
+
+  const cString timerIdText = GetRecordingTimerId(recordingFile.c_str());
+  const char* timerId = *timerIdText;
+
+  if (!timerId || !*timerId) {
+    result.known = true;
+    return result;
+  }
+
+  const std::string value(timerId);
+  const std::string::size_type separator = value.find('@');
+  if (separator == std::string::npos || separator == 0 || separator + 1 >= value.size())
+    return result;
+
+  try {
+    std::size_t parsed = 0;
+    const long id = std::stol(value.substr(0, separator), &parsed, 10);
+    if (parsed != separator || id <= 0 || id > std::numeric_limits<int>::max())
+      return result;
+    result.timerId = static_cast<int>(id);
+  }
+  catch (...) {
+    return result;
+  }
+
+  result.remote = value.substr(separator + 1);
+  if (result.remote.empty())
+    return result;
+
+  LOCK_TIMERS_READ;
+  const cTimer* timer = Timers->GetById(result.timerId, result.remote.c_str());
+  if (!timer)
+    return result;
+
+  result.known = true;
+  result.active = timer->HasFlags(tfActive) || timer->Recording();
+  return result;
+}
+
 RecordingTrashAnalyzer::RecordingTrashAnalyzer(
   const IRecordingLookup& recordingLookup,
   const IRecordingReplayLookup& replayLookup,
   const IRecordingHandlerLookup& recordingHandlerLookup,
-  const IRecordingLocalTimerLookup& localTimerLookup)
+  const IRecordingLocalTimerLookup& localTimerLookup,
+  const IRecordingRemoteTimerLookup& remoteTimerLookup)
   : recordingLookup(recordingLookup),
     replayLookup(replayLookup),
     recordingHandlerLookup(recordingHandlerLookup),
-    localTimerLookup(localTimerLookup)
+    localTimerLookup(localTimerLookup),
+    remoteTimerLookup(remoteTimerLookup)
 {
 }
 
@@ -107,7 +156,14 @@ RecordingMutationAnalysis RecordingTrashAnalyzer::analyze(
   else if (localTimer.active)
     analysis.constraints.push_back(RecordingConstraint::LocalTimerActive);
 
-  analysis.constraints.push_back(RecordingConstraint::UnknownRemoteTimerState);
+  const RecordingRemoteTimerLookupResult remoteTimer =
+    remoteTimerLookup.findActive(recording.recordingFile);
+
+  if (!remoteTimer.known)
+    analysis.constraints.push_back(RecordingConstraint::UnknownRemoteTimerState);
+  else if (remoteTimer.active)
+    analysis.constraints.push_back(RecordingConstraint::RemoteTimerActive);
+
   analysis.constraints.push_back(RecordingConstraint::UnknownSearchTimerState);
 
   return analysis;

--- a/recordinganalysis.h
+++ b/recordinganalysis.h
@@ -17,6 +17,12 @@ struct RecordingHandlerLookupResult
   bool busy = false;
 };
 
+struct RecordingLocalTimerLookupResult
+{
+  bool known = false;
+  bool active = false;
+};
+
 class IRecordingLookup
 {
 public:
@@ -38,6 +44,13 @@ public:
   virtual RecordingHandlerLookupResult getUsage(const std::string& recordingFile) const = 0;
 };
 
+class IRecordingLocalTimerLookup
+{
+public:
+  virtual ~IRecordingLocalTimerLookup() = default;
+  virtual RecordingLocalTimerLookupResult findActive(const std::string& recordingFile) const = 0;
+};
+
 class VdrRecordingLookup : public IRecordingLookup
 {
 public:
@@ -56,13 +69,20 @@ public:
   RecordingHandlerLookupResult getUsage(const std::string& recordingFile) const override;
 };
 
+class VdrRecordingLocalTimerLookup : public IRecordingLocalTimerLookup
+{
+public:
+  RecordingLocalTimerLookupResult findActive(const std::string& recordingFile) const override;
+};
+
 class RecordingTrashAnalyzer
 {
 public:
   RecordingTrashAnalyzer(
     const IRecordingLookup& recordingLookup,
     const IRecordingReplayLookup& replayLookup,
-    const IRecordingHandlerLookup& recordingHandlerLookup);
+    const IRecordingHandlerLookup& recordingHandlerLookup,
+    const IRecordingLocalTimerLookup& localTimerLookup);
 
   RecordingMutationAnalysis analyze(const std::string& recordingFile) const;
 
@@ -70,6 +90,7 @@ private:
   const IRecordingLookup& recordingLookup;
   const IRecordingReplayLookup& replayLookup;
   const IRecordingHandlerLookup& recordingHandlerLookup;
+  const IRecordingLocalTimerLookup& localTimerLookup;
 };
 
 #endif

--- a/recordinganalysis.h
+++ b/recordinganalysis.h
@@ -31,6 +31,13 @@ struct RecordingRemoteTimerLookupResult
   std::string remote;
 };
 
+struct RecordingSearchTimerLookupResult
+{
+  bool known = false;
+  bool searchTimerRecording = false;
+  int searchTimerId = -1;
+};
+
 class IRecordingLookup
 {
 public:
@@ -66,6 +73,13 @@ public:
   virtual RecordingRemoteTimerLookupResult findActive(const std::string& recordingFile) const = 0;
 };
 
+class IRecordingSearchTimerLookup
+{
+public:
+  virtual ~IRecordingSearchTimerLookup() = default;
+  virtual RecordingSearchTimerLookupResult findOrigin(const std::string& recordingFile) const = 0;
+};
+
 class VdrRecordingLookup : public IRecordingLookup
 {
 public:
@@ -96,6 +110,12 @@ public:
   RecordingRemoteTimerLookupResult findActive(const std::string& recordingFile) const override;
 };
 
+class VdrRecordingSearchTimerLookup : public IRecordingSearchTimerLookup
+{
+public:
+  RecordingSearchTimerLookupResult findOrigin(const std::string& recordingFile) const override;
+};
+
 class RecordingTrashAnalyzer
 {
 public:
@@ -104,7 +124,8 @@ public:
     const IRecordingReplayLookup& replayLookup,
     const IRecordingHandlerLookup& recordingHandlerLookup,
     const IRecordingLocalTimerLookup& localTimerLookup,
-    const IRecordingRemoteTimerLookup& remoteTimerLookup);
+    const IRecordingRemoteTimerLookup& remoteTimerLookup,
+    const IRecordingSearchTimerLookup& searchTimerLookup);
 
   RecordingMutationAnalysis analyze(const std::string& recordingFile) const;
 
@@ -114,6 +135,7 @@ private:
   const IRecordingHandlerLookup& recordingHandlerLookup;
   const IRecordingLocalTimerLookup& localTimerLookup;
   const IRecordingRemoteTimerLookup& remoteTimerLookup;
+  const IRecordingSearchTimerLookup& searchTimerLookup;
 };
 
 #endif

--- a/recordinganalysis.h
+++ b/recordinganalysis.h
@@ -23,6 +23,14 @@ struct RecordingLocalTimerLookupResult
   bool active = false;
 };
 
+struct RecordingRemoteTimerLookupResult
+{
+  bool known = false;
+  bool active = false;
+  int timerId = 0;
+  std::string remote;
+};
+
 class IRecordingLookup
 {
 public:
@@ -51,6 +59,13 @@ public:
   virtual RecordingLocalTimerLookupResult findActive(const std::string& recordingFile) const = 0;
 };
 
+class IRecordingRemoteTimerLookup
+{
+public:
+  virtual ~IRecordingRemoteTimerLookup() = default;
+  virtual RecordingRemoteTimerLookupResult findActive(const std::string& recordingFile) const = 0;
+};
+
 class VdrRecordingLookup : public IRecordingLookup
 {
 public:
@@ -75,6 +90,12 @@ public:
   RecordingLocalTimerLookupResult findActive(const std::string& recordingFile) const override;
 };
 
+class VdrRecordingRemoteTimerLookup : public IRecordingRemoteTimerLookup
+{
+public:
+  RecordingRemoteTimerLookupResult findActive(const std::string& recordingFile) const override;
+};
+
 class RecordingTrashAnalyzer
 {
 public:
@@ -82,7 +103,8 @@ public:
     const IRecordingLookup& recordingLookup,
     const IRecordingReplayLookup& replayLookup,
     const IRecordingHandlerLookup& recordingHandlerLookup,
-    const IRecordingLocalTimerLookup& localTimerLookup);
+    const IRecordingLocalTimerLookup& localTimerLookup,
+    const IRecordingRemoteTimerLookup& remoteTimerLookup);
 
   RecordingMutationAnalysis analyze(const std::string& recordingFile) const;
 
@@ -91,6 +113,7 @@ private:
   const IRecordingReplayLookup& replayLookup;
   const IRecordingHandlerLookup& recordingHandlerLookup;
   const IRecordingLocalTimerLookup& localTimerLookup;
+  const IRecordingRemoteTimerLookup& remoteTimerLookup;
 };
 
 #endif

--- a/recordinganalysis.h
+++ b/recordinganalysis.h
@@ -1,0 +1,54 @@
+#ifndef __RECORDINGANALYSIS_H
+#define __RECORDINGANALYSIS_H
+
+#include "recordingmutation.h"
+
+#include <string>
+
+struct RecordingLookupResult
+{
+  bool found = false;
+  std::string recordingFile;
+};
+
+class IRecordingLookup
+{
+public:
+  virtual ~IRecordingLookup() = default;
+  virtual RecordingLookupResult find(const std::string& recordingFile) const = 0;
+};
+
+class IRecordingReplayLookup
+{
+public:
+  virtual ~IRecordingReplayLookup() = default;
+  virtual bool isReplaying(const std::string& recordingFile) const = 0;
+};
+
+class VdrRecordingLookup : public IRecordingLookup
+{
+public:
+  RecordingLookupResult find(const std::string& recordingFile) const override;
+};
+
+class VdrRecordingReplayLookup : public IRecordingReplayLookup
+{
+public:
+  bool isReplaying(const std::string& recordingFile) const override;
+};
+
+class RecordingTrashAnalyzer
+{
+public:
+  RecordingTrashAnalyzer(
+    const IRecordingLookup& recordingLookup,
+    const IRecordingReplayLookup& replayLookup);
+
+  RecordingMutationAnalysis analyze(const std::string& recordingFile) const;
+
+private:
+  const IRecordingLookup& recordingLookup;
+  const IRecordingReplayLookup& replayLookup;
+};
+
+#endif

--- a/recordinganalysis.h
+++ b/recordinganalysis.h
@@ -11,6 +11,12 @@ struct RecordingLookupResult
   std::string recordingFile;
 };
 
+struct RecordingHandlerLookupResult
+{
+  bool known = false;
+  bool busy = false;
+};
+
 class IRecordingLookup
 {
 public:
@@ -25,6 +31,13 @@ public:
   virtual bool isReplaying(const std::string& recordingFile) const = 0;
 };
 
+class IRecordingHandlerLookup
+{
+public:
+  virtual ~IRecordingHandlerLookup() = default;
+  virtual RecordingHandlerLookupResult getUsage(const std::string& recordingFile) const = 0;
+};
+
 class VdrRecordingLookup : public IRecordingLookup
 {
 public:
@@ -37,18 +50,26 @@ public:
   bool isReplaying(const std::string& recordingFile) const override;
 };
 
+class VdrRecordingHandlerLookup : public IRecordingHandlerLookup
+{
+public:
+  RecordingHandlerLookupResult getUsage(const std::string& recordingFile) const override;
+};
+
 class RecordingTrashAnalyzer
 {
 public:
   RecordingTrashAnalyzer(
     const IRecordingLookup& recordingLookup,
-    const IRecordingReplayLookup& replayLookup);
+    const IRecordingReplayLookup& replayLookup,
+    const IRecordingHandlerLookup& recordingHandlerLookup);
 
   RecordingMutationAnalysis analyze(const std::string& recordingFile) const;
 
 private:
   const IRecordingLookup& recordingLookup;
   const IRecordingReplayLookup& replayLookup;
+  const IRecordingHandlerLookup& recordingHandlerLookup;
 };
 
 #endif

--- a/recordingexecution.cpp
+++ b/recordingexecution.cpp
@@ -1,0 +1,67 @@
+#include "recordingexecution.h"
+
+namespace {
+
+bool sameRevision(
+  const RecordingMutationRevision& left,
+  const RecordingMutationRevision& right)
+{
+  return left.recordingFile == right.recordingFile
+    && left.recordingsState == right.recordingsState
+    && left.timersState == right.timersState;
+}
+
+}
+
+RecordingTrashExecutionGate::RecordingTrashExecutionGate(
+  const RecordingTrashAnalyzer& analyzer,
+  const RecordingMutationPlanner& planner)
+  : analyzer(analyzer),
+    planner(planner)
+{
+}
+
+RecordingTrashExecutionGateResult RecordingTrashExecutionGate::validate(
+  const std::string& recordingFile,
+  const RecordingMutationRevision& expectedRevision,
+  const RecordingMutationPolicy& policy) const
+{
+  RecordingTrashExecutionGateResult result;
+  result.recordingFile = recordingFile;
+  result.expectedRevision = expectedRevision;
+
+  const RecordingMutationAnalysis analysis = analyzer.analyze(recordingFile);
+  const RecordingMutationPlan plan = planner.buildTrashPlan(analysis, policy);
+
+  result.currentRevision = analysis.revision;
+  result.blockers = plan.blockers;
+  result.warnings = plan.warnings;
+
+  if (!sameRevision(expectedRevision, analysis.revision)) {
+    result.status = RecordingTrashExecutionGateStatus::Conflict;
+    return result;
+  }
+
+  if (!plan.executable) {
+    result.status = RecordingTrashExecutionGateStatus::Blocked;
+    return result;
+  }
+
+  result.status = RecordingTrashExecutionGateStatus::Ready;
+  return result;
+}
+
+const char* RecordingTrashExecutionGateStatusName(
+  RecordingTrashExecutionGateStatus status)
+{
+  switch (status) {
+    case RecordingTrashExecutionGateStatus::Ready:
+      return "ready";
+    case RecordingTrashExecutionGateStatus::Conflict:
+      return "conflict";
+    case RecordingTrashExecutionGateStatus::Blocked:
+      return "blocked";
+  }
+
+  return "blocked";
+}

--- a/recordingexecution.h
+++ b/recordingexecution.h
@@ -1,0 +1,47 @@
+#ifndef __RECORDINGEXECUTION_H
+#define __RECORDINGEXECUTION_H
+
+#include "recordinganalysis.h"
+#include "recordingmutation.h"
+
+#include <string>
+#include <vector>
+
+enum class RecordingTrashExecutionGateStatus
+{
+  Ready,
+  Conflict,
+  Blocked
+};
+
+struct RecordingTrashExecutionGateResult
+{
+  RecordingTrashExecutionGateStatus status = RecordingTrashExecutionGateStatus::Blocked;
+  std::string recordingFile;
+  RecordingMutationRevision expectedRevision;
+  RecordingMutationRevision currentRevision;
+  std::vector<RecordingConstraint> blockers;
+  std::vector<std::string> warnings;
+};
+
+class RecordingTrashExecutionGate
+{
+public:
+  RecordingTrashExecutionGate(
+    const RecordingTrashAnalyzer& analyzer,
+    const RecordingMutationPlanner& planner);
+
+  RecordingTrashExecutionGateResult validate(
+    const std::string& recordingFile,
+    const RecordingMutationRevision& expectedRevision,
+    const RecordingMutationPolicy& policy) const;
+
+private:
+  const RecordingTrashAnalyzer& analyzer;
+  const RecordingMutationPlanner& planner;
+};
+
+const char* RecordingTrashExecutionGateStatusName(
+  RecordingTrashExecutionGateStatus status);
+
+#endif

--- a/recordingmutation.cpp
+++ b/recordingmutation.cpp
@@ -1,0 +1,117 @@
+#include "recordingmutation.h"
+
+#include <algorithm>
+
+bool RecordingMutationAnalysis::hasConstraint(RecordingConstraint constraint) const
+{
+  return std::find(constraints.begin(), constraints.end(), constraint) != constraints.end();
+}
+
+namespace {
+
+void addBlocker(RecordingMutationPlan& plan, RecordingConstraint constraint)
+{
+  if (std::find(plan.blockers.begin(), plan.blockers.end(), constraint) == plan.blockers.end())
+    plan.blockers.push_back(constraint);
+}
+
+void addStep(RecordingMutationPlan& plan, RecordingMutationStep step)
+{
+  if (std::find(plan.steps.begin(), plan.steps.end(), step) == plan.steps.end())
+    plan.steps.push_back(step);
+}
+
+}
+
+RecordingMutationPlan RecordingMutationPlanner::buildTrashPlan(
+  const RecordingMutationAnalysis& analysis,
+  const RecordingMutationPolicy& policy) const
+{
+  RecordingMutationPlan plan;
+  plan.type = RecordingMutationType::Trash;
+  plan.warnings = analysis.warnings;
+  plan.expectedRevision = analysis.revision;
+
+  if (analysis.type != RecordingMutationType::Trash)
+    addBlocker(plan, RecordingConstraint::RecordingMissing);
+
+  if (analysis.hasConstraint(RecordingConstraint::RecordingMissing))
+    addBlocker(plan, RecordingConstraint::RecordingMissing);
+
+  if (analysis.hasConstraint(RecordingConstraint::UnknownTimerState))
+    addBlocker(plan, RecordingConstraint::UnknownTimerState);
+
+  if (analysis.hasConstraint(RecordingConstraint::UnknownSearchTimerState))
+    addBlocker(plan, RecordingConstraint::UnknownSearchTimerState);
+
+  if (analysis.hasConstraint(RecordingConstraint::RecordingHandlerBusy)) {
+    if (policy.allowRecordingHandlerStop)
+      addStep(plan, RecordingMutationStep::StopRecordingHandler);
+    else
+      addBlocker(plan, RecordingConstraint::RecordingHandlerBusy);
+  }
+
+  if (analysis.hasConstraint(RecordingConstraint::ReplayActive)) {
+    if (policy.allowReplayStop)
+      addStep(plan, RecordingMutationStep::StopReplay);
+    else
+      addBlocker(plan, RecordingConstraint::ReplayActive);
+  }
+
+  if (analysis.hasConstraint(RecordingConstraint::LocalTimerActive)) {
+    if (policy.allowLocalTimerStop)
+      addStep(plan, RecordingMutationStep::DeactivateLocalTimer);
+    else
+      addBlocker(plan, RecordingConstraint::LocalTimerActive);
+  }
+
+  if (analysis.hasConstraint(RecordingConstraint::RemoteTimerActive)) {
+    if (policy.allowRemoteTimerStop)
+      addStep(plan, RecordingMutationStep::DeactivateRemoteTimer);
+    else
+      addBlocker(plan, RecordingConstraint::RemoteTimerActive);
+  }
+
+  if (analysis.hasConstraint(RecordingConstraint::SearchTimerRecording))
+    plan.warnings.push_back("EPGSearch may classify an interrupted recording as incomplete.");
+
+  if (plan.blockers.empty()) {
+    addStep(plan, RecordingMutationStep::TrashRecording);
+    addStep(plan, RecordingMutationStep::RefreshRecordings);
+    addStep(plan, RecordingMutationStep::NotifyChange);
+    plan.executable = true;
+  }
+
+  return plan;
+}
+
+const char* RecordingConstraintName(RecordingConstraint constraint)
+{
+  switch (constraint) {
+    case RecordingConstraint::RecordingMissing: return "recording-missing";
+    case RecordingConstraint::RecordingHandlerBusy: return "recording-handler-busy";
+    case RecordingConstraint::ReplayActive: return "replay-active";
+    case RecordingConstraint::LocalTimerActive: return "local-timer-active";
+    case RecordingConstraint::RemoteTimerActive: return "remote-timer-active";
+    case RecordingConstraint::SearchTimerRecording: return "searchtimer-recording";
+    case RecordingConstraint::UnknownTimerState: return "unknown-timer-state";
+    case RecordingConstraint::UnknownSearchTimerState: return "unknown-searchtimer-state";
+  }
+  return "unknown";
+}
+
+const char* RecordingMutationStepName(RecordingMutationStep step)
+{
+  switch (step) {
+    case RecordingMutationStep::StopRecordingHandler: return "stop-recording-handler";
+    case RecordingMutationStep::StopReplay: return "stop-replay";
+    case RecordingMutationStep::DeactivateLocalTimer: return "deactivate-local-timer";
+    case RecordingMutationStep::DeactivateRemoteTimer: return "deactivate-remote-timer";
+    case RecordingMutationStep::TrashRecording: return "trash-recording";
+    case RecordingMutationStep::RestoreRecording: return "restore-recording";
+    case RecordingMutationStep::PurgeRecording: return "purge-recording";
+    case RecordingMutationStep::RefreshRecordings: return "refresh-recordings";
+    case RecordingMutationStep::NotifyChange: return "notify-change";
+  }
+  return "unknown";
+}

--- a/recordingmutation.cpp
+++ b/recordingmutation.cpp
@@ -41,8 +41,11 @@ RecordingMutationPlan RecordingMutationPlanner::buildTrashPlan(
   if (analysis.hasConstraint(RecordingConstraint::UnknownRecordingHandlerState))
     addBlocker(plan, RecordingConstraint::UnknownRecordingHandlerState);
 
-  if (analysis.hasConstraint(RecordingConstraint::UnknownTimerState))
-    addBlocker(plan, RecordingConstraint::UnknownTimerState);
+  if (analysis.hasConstraint(RecordingConstraint::UnknownLocalTimerState))
+    addBlocker(plan, RecordingConstraint::UnknownLocalTimerState);
+
+  if (analysis.hasConstraint(RecordingConstraint::UnknownRemoteTimerState))
+    addBlocker(plan, RecordingConstraint::UnknownRemoteTimerState);
 
   if (analysis.hasConstraint(RecordingConstraint::UnknownSearchTimerState))
     addBlocker(plan, RecordingConstraint::UnknownSearchTimerState);
@@ -98,7 +101,8 @@ const char* RecordingConstraintName(RecordingConstraint constraint)
     case RecordingConstraint::RemoteTimerActive: return "remote-timer-active";
     case RecordingConstraint::SearchTimerRecording: return "searchtimer-recording";
     case RecordingConstraint::UnknownRecordingHandlerState: return "unknown-recording-handler-state";
-    case RecordingConstraint::UnknownTimerState: return "unknown-timer-state";
+    case RecordingConstraint::UnknownLocalTimerState: return "unknown-local-timer-state";
+    case RecordingConstraint::UnknownRemoteTimerState: return "unknown-remote-timer-state";
     case RecordingConstraint::UnknownSearchTimerState: return "unknown-searchtimer-state";
   }
   return "unknown";

--- a/recordingmutation.cpp
+++ b/recordingmutation.cpp
@@ -38,6 +38,9 @@ RecordingMutationPlan RecordingMutationPlanner::buildTrashPlan(
   if (analysis.hasConstraint(RecordingConstraint::RecordingMissing))
     addBlocker(plan, RecordingConstraint::RecordingMissing);
 
+  if (analysis.hasConstraint(RecordingConstraint::UnknownRecordingHandlerState))
+    addBlocker(plan, RecordingConstraint::UnknownRecordingHandlerState);
+
   if (analysis.hasConstraint(RecordingConstraint::UnknownTimerState))
     addBlocker(plan, RecordingConstraint::UnknownTimerState);
 
@@ -94,6 +97,7 @@ const char* RecordingConstraintName(RecordingConstraint constraint)
     case RecordingConstraint::LocalTimerActive: return "local-timer-active";
     case RecordingConstraint::RemoteTimerActive: return "remote-timer-active";
     case RecordingConstraint::SearchTimerRecording: return "searchtimer-recording";
+    case RecordingConstraint::UnknownRecordingHandlerState: return "unknown-recording-handler-state";
     case RecordingConstraint::UnknownTimerState: return "unknown-timer-state";
     case RecordingConstraint::UnknownSearchTimerState: return "unknown-searchtimer-state";
   }

--- a/recordingmutation.h
+++ b/recordingmutation.h
@@ -1,0 +1,88 @@
+#ifndef __RECORDINGMUTATION_H
+#define __RECORDINGMUTATION_H
+
+#include <string>
+#include <vector>
+
+enum class RecordingMutationType
+{
+  Trash,
+  Restore,
+  Purge,
+  Move,
+  Rename
+};
+
+enum class RecordingConstraint
+{
+  RecordingMissing,
+  RecordingHandlerBusy,
+  ReplayActive,
+  LocalTimerActive,
+  RemoteTimerActive,
+  SearchTimerRecording,
+  UnknownTimerState,
+  UnknownSearchTimerState
+};
+
+enum class RecordingMutationStep
+{
+  StopRecordingHandler,
+  StopReplay,
+  DeactivateLocalTimer,
+  DeactivateRemoteTimer,
+  TrashRecording,
+  RestoreRecording,
+  PurgeRecording,
+  RefreshRecordings,
+  NotifyChange
+};
+
+struct RecordingMutationRevision
+{
+  std::string recordingFile;
+  long long recordingsState = 0;
+  long long timersState = 0;
+};
+
+struct RecordingMutationAnalysis
+{
+  RecordingMutationType type = RecordingMutationType::Trash;
+  std::string recordingFile;
+  std::vector<RecordingConstraint> constraints;
+  std::vector<std::string> warnings;
+  RecordingMutationRevision revision;
+
+  bool hasConstraint(RecordingConstraint constraint) const;
+};
+
+struct RecordingMutationPolicy
+{
+  bool allowRecordingHandlerStop = false;
+  bool allowReplayStop = false;
+  bool allowLocalTimerStop = false;
+  bool allowRemoteTimerStop = false;
+};
+
+struct RecordingMutationPlan
+{
+  RecordingMutationType type = RecordingMutationType::Trash;
+  bool executable = false;
+  std::vector<RecordingMutationStep> steps;
+  std::vector<RecordingConstraint> blockers;
+  std::vector<std::string> warnings;
+  RecordingMutationRevision expectedRevision;
+};
+
+class RecordingMutationPlanner
+{
+public:
+  RecordingMutationPlan buildTrashPlan(
+    const RecordingMutationAnalysis& analysis,
+    const RecordingMutationPolicy& policy) const;
+};
+
+const char* RecordingConstraintName(RecordingConstraint constraint);
+const char* RecordingMutationStepName(RecordingMutationStep step);
+
+#endif

--- a/recordingmutation.h
+++ b/recordingmutation.h
@@ -22,7 +22,8 @@ enum class RecordingConstraint
   RemoteTimerActive,
   SearchTimerRecording,
   UnknownRecordingHandlerState,
-  UnknownTimerState,
+  UnknownLocalTimerState,
+  UnknownRemoteTimerState,
   UnknownSearchTimerState
 };
 

--- a/recordingmutation.h
+++ b/recordingmutation.h
@@ -21,6 +21,7 @@ enum class RecordingConstraint
   LocalTimerActive,
   RemoteTimerActive,
   SearchTimerRecording,
+  UnknownRecordingHandlerState,
   UnknownTimerState,
   UnknownSearchTimerState
 };

--- a/recordingpreflight.cpp
+++ b/recordingpreflight.cpp
@@ -1,0 +1,34 @@
+#include "recordingpreflight.h"
+
+RecordingTrashPreflightService::RecordingTrashPreflightService(
+  const RecordingTrashAnalyzer& analyzer,
+  const RecordingMutationPlanner& planner)
+  : analyzer(analyzer),
+    planner(planner)
+{
+}
+
+RecordingTrashPreflightResult RecordingTrashPreflightService::preview(
+  const std::string& recordingFile,
+  const RecordingMutationPolicy& policy) const
+{
+  RecordingTrashPreflightResult result;
+  const RecordingMutationAnalysis analysis = analyzer.analyze(recordingFile);
+  const RecordingMutationPlan plan = planner.buildTrashPlan(analysis, policy);
+
+  result.executable = plan.executable;
+  result.recordingFile = analysis.recordingFile;
+  result.warnings = plan.warnings;
+  result.revision = plan.expectedRevision;
+
+  for (const RecordingConstraint constraint : analysis.constraints)
+    result.constraints.push_back(RecordingConstraintName(constraint));
+
+  for (const RecordingConstraint blocker : plan.blockers)
+    result.blockers.push_back(RecordingConstraintName(blocker));
+
+  for (const RecordingMutationStep step : plan.steps)
+    result.steps.push_back(RecordingMutationStepName(step));
+
+  return result;
+}

--- a/recordingpreflight.h
+++ b/recordingpreflight.h
@@ -1,0 +1,37 @@
+#ifndef __RECORDINGPREFLIGHT_H
+#define __RECORDINGPREFLIGHT_H
+
+#include "recordinganalysis.h"
+#include "recordingmutation.h"
+
+#include <string>
+#include <vector>
+
+struct RecordingTrashPreflightResult
+{
+  bool executable = false;
+  std::string recordingFile;
+  std::vector<std::string> constraints;
+  std::vector<std::string> blockers;
+  std::vector<std::string> warnings;
+  std::vector<std::string> steps;
+  RecordingMutationRevision revision;
+};
+
+class RecordingTrashPreflightService
+{
+public:
+  RecordingTrashPreflightService(
+    const RecordingTrashAnalyzer& analyzer,
+    const RecordingMutationPlanner& planner);
+
+  RecordingTrashPreflightResult preview(
+    const std::string& recordingFile,
+    const RecordingMutationPolicy& policy) const;
+
+private:
+  const RecordingTrashAnalyzer& analyzer;
+  const RecordingMutationPlanner& planner;
+};
+
+#endif

--- a/recordingpreview.cpp
+++ b/recordingpreview.cpp
@@ -1,0 +1,75 @@
+#include "recordingpreview.h"
+
+#include "recordinganalysis.h"
+#include "recordingmutation.h"
+#include "recordingpreflight.h"
+#include "tools.h"
+
+#include <cxxtools/jsonserializer.h>
+
+void RecordingTrashPreviewResponder::reply(
+  std::ostream& out,
+  cxxtools::http::Request& request,
+  cxxtools::http::Reply& reply)
+{
+  QueryHandler::addHeader(reply);
+
+  if (request.method() == "OPTIONS") {
+    reply.addHeader("Allow", "POST");
+    reply.httpReturn(200, "OK");
+    return;
+  }
+
+  if (request.method() != "POST") {
+    reply.httpReturn(501, "Only POST method is supported by the /recordings/trash/preview service.");
+    return;
+  }
+
+  QueryHandler query("/recordings/trash/preview", request);
+  const std::string recordingFile = query.getBodyAsString("file");
+
+  if (recordingFile.empty()) {
+    reply.httpReturn(400, "Recording file is missing.");
+    return;
+  }
+
+  RecordingMutationPolicy policy;
+  policy.allowRecordingHandlerStop = query.getBodyAsBool("allow_recording_handler_stop");
+  policy.allowReplayStop = query.getBodyAsBool("allow_replay_stop");
+  policy.allowLocalTimerStop = query.getBodyAsBool("allow_local_timer_stop");
+  policy.allowRemoteTimerStop = query.getBodyAsBool("allow_remote_timer_stop");
+
+  VdrRecordingLookup recordingLookup;
+  VdrRecordingReplayLookup replayLookup;
+  VdrRecordingHandlerLookup recordingHandlerLookup;
+  VdrRecordingLocalTimerLookup localTimerLookup;
+  VdrRecordingRemoteTimerLookup remoteTimerLookup;
+  VdrRecordingSearchTimerLookup searchTimerLookup;
+
+  RecordingTrashAnalyzer analyzer(
+    recordingLookup,
+    replayLookup,
+    recordingHandlerLookup,
+    localTimerLookup,
+    remoteTimerLookup,
+    searchTimerLookup);
+
+  RecordingMutationPlanner planner;
+  RecordingTrashPreflightService preflightService(analyzer, planner);
+  const RecordingTrashPreflightResult result =
+    preflightService.preview(recordingFile, policy);
+
+  reply.addHeader("Content-Type", "application/json; charset=utf-8");
+
+  cxxtools::JsonSerializer serializer(out);
+  serializer.serialize(result.executable, "executable");
+  serializer.serialize(result.recordingFile, "recording_file");
+  serializer.serialize(result.constraints, "constraints");
+  serializer.serialize(result.blockers, "blockers");
+  serializer.serialize(result.warnings, "warnings");
+  serializer.serialize(result.steps, "steps");
+  serializer.serialize(result.revision.recordingFile, "revision_recording_file");
+  serializer.serialize(result.revision.recordingsState, "revision_recordings_state");
+  serializer.serialize(result.revision.timersState, "revision_timers_state");
+  serializer.finish();
+}

--- a/recordingpreview.h
+++ b/recordingpreview.h
@@ -1,0 +1,25 @@
+#ifndef __RECORDINGPREVIEW_H
+#define __RECORDINGPREVIEW_H
+
+#include <cxxtools/http/reply.h>
+#include <cxxtools/http/request.h>
+#include <cxxtools/http/responder.h>
+
+class RecordingTrashPreviewResponder : public cxxtools::http::Responder
+{
+public:
+  explicit RecordingTrashPreviewResponder(cxxtools::http::Service& service)
+    : cxxtools::http::Responder(service)
+  {
+  }
+
+  void reply(
+    std::ostream& out,
+    cxxtools::http::Request& request,
+    cxxtools::http::Reply& reply) override;
+};
+
+typedef cxxtools::http::CachedService<RecordingTrashPreviewResponder>
+  RecordingTrashPreviewService;
+
+#endif

--- a/recordingtrash.cpp
+++ b/recordingtrash.cpp
@@ -1,0 +1,131 @@
+#include "recordingtrash.h"
+
+#include "recordinganalysis.h"
+#include "recordingexecution.h"
+#include "recordingmutation.h"
+#include "recordingtrashexecutor.h"
+#include "tools.h"
+
+#include <cxxtools/jsonserializer.h>
+
+#include <string>
+
+namespace {
+
+bool parseLongLong(const std::string& value, long long& result)
+{
+  if (value.empty())
+    return false;
+
+  try {
+    std::size_t parsed = 0;
+    result = std::stoll(value, &parsed, 10);
+    return parsed == value.size();
+  }
+  catch (...) {
+    return false;
+  }
+}
+
+}
+
+void RecordingTrashResponder::reply(
+  std::ostream& out,
+  cxxtools::http::Request& request,
+  cxxtools::http::Reply& reply)
+{
+  QueryHandler::addHeader(reply);
+
+  if (request.method() == "OPTIONS") {
+    reply.addHeader("Allow", "POST");
+    reply.httpReturn(200, "OK");
+    return;
+  }
+
+  if (request.method() != "POST") {
+    reply.httpReturn(501, "Only POST method is supported by the /recordings/trash service.");
+    return;
+  }
+
+  QueryHandler query("/recordings/trash", request);
+  const std::string recordingFile = query.getBodyAsString("file");
+  const std::string recordingsStateText =
+    query.getBodyAsString("revision_recordings_state");
+  const std::string timersStateText =
+    query.getBodyAsString("revision_timers_state");
+
+  long long recordingsState = 0;
+  long long timersState = 0;
+
+  if (recordingFile.empty()) {
+    reply.httpReturn(400, "Recording file is missing.");
+    return;
+  }
+
+  if (!parseLongLong(recordingsStateText, recordingsState) ||
+      !parseLongLong(timersStateText, timersState)) {
+    reply.httpReturn(400, "Recording revision is missing or invalid.");
+    return;
+  }
+
+  RecordingMutationPolicy policy;
+  policy.allowRecordingHandlerStop = false;
+  policy.allowReplayStop = false;
+  policy.allowLocalTimerStop = false;
+  policy.allowRemoteTimerStop = false;
+
+  VdrRecordingLookup recordingLookup;
+  VdrRecordingReplayLookup replayLookup;
+  VdrRecordingHandlerLookup recordingHandlerLookup;
+  VdrRecordingLocalTimerLookup localTimerLookup;
+  VdrRecordingRemoteTimerLookup remoteTimerLookup;
+  VdrRecordingSearchTimerLookup searchTimerLookup;
+
+  RecordingTrashAnalyzer analyzer(
+    recordingLookup,
+    replayLookup,
+    recordingHandlerLookup,
+    localTimerLookup,
+    remoteTimerLookup,
+    searchTimerLookup);
+
+  RecordingMutationPlanner planner;
+  RecordingTrashExecutionGate gate(analyzer, planner);
+  RecordingTrashExecutor executor(gate);
+
+  RecordingMutationRevision expectedRevision;
+  expectedRevision.recordingFile = recordingFile;
+  expectedRevision.recordingsState = recordingsState;
+  expectedRevision.timersState = timersState;
+
+  const RecordingTrashExecutorResult result =
+    executor.executeNormalCase(recordingFile, expectedRevision, policy);
+
+  switch (result.status) {
+    case RecordingTrashExecutorStatus::Conflict:
+      reply.httpReturn(409, result.message);
+      return;
+    case RecordingTrashExecutorStatus::Blocked:
+      reply.httpReturn(423, result.message);
+      return;
+    case RecordingTrashExecutorStatus::NotFound:
+      reply.httpReturn(404, result.message);
+      return;
+    case RecordingTrashExecutorStatus::Failed:
+      reply.httpReturn(500, result.message);
+      return;
+    case RecordingTrashExecutorStatus::Trashed:
+      break;
+  }
+
+  reply.addHeader("Content-Type", "application/json; charset=utf-8");
+
+  cxxtools::JsonSerializer serializer(out);
+  serializer.serialize(
+    std::string(RecordingTrashExecutorStatusName(result.status)),
+    "status");
+  serializer.serialize(result.recordingFile, "recording_file");
+  serializer.serialize(result.deletedRecordingFile, "deleted_recording_file");
+  serializer.serialize(result.message, "message");
+  serializer.finish();
+}

--- a/recordingtrash.cpp
+++ b/recordingtrash.cpp
@@ -115,6 +115,7 @@ void RecordingTrashResponder::reply(
       reply.httpReturn(500, result.message);
       return;
     case RecordingTrashExecutorStatus::Trashed:
+    case RecordingTrashExecutorStatus::AlreadyTrashed:
       break;
   }
 

--- a/recordingtrash.h
+++ b/recordingtrash.h
@@ -1,0 +1,25 @@
+#ifndef __RECORDINGTRASH_H
+#define __RECORDINGTRASH_H
+
+#include <cxxtools/http/request.h>
+#include <cxxtools/http/reply.h>
+#include <cxxtools/http/responder.h>
+
+class RecordingTrashResponder : public cxxtools::http::Responder
+{
+public:
+  explicit RecordingTrashResponder(cxxtools::http::Service& service)
+    : cxxtools::http::Responder(service)
+  {
+  }
+
+  void reply(
+    std::ostream& out,
+    cxxtools::http::Request& request,
+    cxxtools::http::Reply& reply) override;
+};
+
+typedef cxxtools::http::CachedService<RecordingTrashResponder>
+  RecordingTrashService;
+
+#endif

--- a/recordingtrashexecutor.cpp
+++ b/recordingtrashexecutor.cpp
@@ -1,0 +1,134 @@
+#include "recordingtrashexecutor.h"
+
+#include "changestatetracker.h"
+
+#include <cstring>
+
+#include <vdr/menu.h>
+#include <vdr/recording.h>
+
+namespace {
+
+std::string deletedFileName(const std::string& recordingFile)
+{
+  static const std::string recordingSuffix = ".rec";
+  if (recordingFile.size() >= recordingSuffix.size() &&
+      recordingFile.compare(
+        recordingFile.size() - recordingSuffix.size(),
+        recordingSuffix.size(),
+        recordingSuffix) == 0)
+    return recordingFile.substr(0, recordingFile.size() - recordingSuffix.size()) + ".del";
+
+  return std::string();
+}
+
+}
+
+RecordingTrashExecutor::RecordingTrashExecutor(const RecordingTrashExecutionGate& gate)
+  : gate(gate)
+{
+}
+
+RecordingTrashExecutorResult RecordingTrashExecutor::executeNormalCase(
+  const std::string& recordingFile,
+  const RecordingMutationRevision& expectedRevision,
+  const RecordingMutationPolicy& policy) const
+{
+  RecordingTrashExecutorResult result;
+  result.recordingFile = recordingFile;
+  result.gate = gate.validate(recordingFile, expectedRevision, policy);
+
+  if (result.gate.status == RecordingTrashExecutionGateStatus::Conflict) {
+    result.status = RecordingTrashExecutorStatus::Conflict;
+    result.message = "Recording state changed after preview.";
+    return result;
+  }
+
+  if (result.gate.status != RecordingTrashExecutionGateStatus::Ready) {
+    result.status = RecordingTrashExecutorStatus::Blocked;
+    result.message = "Recording trash execution is blocked by the current state or policy.";
+    return result;
+  }
+
+  const std::string targetFile = deletedFileName(recordingFile);
+  if (targetFile.empty()) {
+    result.status = RecordingTrashExecutorStatus::Blocked;
+    result.message = "Only active .rec recordings can be moved to the VDR trash.";
+    return result;
+  }
+
+  LOCK_TIMERS_WRITE;
+  LOCK_RECORDINGS_WRITE;
+
+  cRecording* recording = Recordings->GetByName(recordingFile.c_str());
+  if (!recording) {
+    result.status = RecordingTrashExecutorStatus::NotFound;
+    result.message = "Recording disappeared before execution.";
+    return result;
+  }
+
+  const char* nowReplaying = cReplayControl::NowReplaying();
+  if (nowReplaying && std::strcmp(nowReplaying, recordingFile.c_str()) == 0) {
+    result.status = RecordingTrashExecutorStatus::Conflict;
+    result.message = "Recording started replaying after validation.";
+    return result;
+  }
+
+  if (RecordingsHandler.GetUsage(recordingFile.c_str()) != ruNone) {
+    result.status = RecordingTrashExecutorStatus::Conflict;
+    result.message = "Recording handler usage changed after validation.";
+    return result;
+  }
+
+  if (cRecordControls::GetRecordControl(recordingFile.c_str()) != nullptr) {
+    result.status = RecordingTrashExecutorStatus::Conflict;
+    result.message = "A local recording control became active after validation.";
+    return result;
+  }
+
+  const cString timerIdText = GetRecordingTimerId(recordingFile.c_str());
+  const char* timerId = *timerIdText;
+  if (timerId && *timerId) {
+    result.status = RecordingTrashExecutorStatus::Conflict;
+    result.message = "A timer association appeared after validation.";
+    return result;
+  }
+
+  if (!recording->Delete()) {
+    result.status = RecordingTrashExecutorStatus::Failed;
+    result.message = "VDR failed to rename the recording into its deleted state.";
+    return result;
+  }
+
+  {
+    LOCK_DELETEDRECORDINGS_WRITE;
+    Recordings->Del(recording, false);
+    DeletedRecordings->Add(recording);
+  }
+
+  cVideoDiskUsage::ForceCheck();
+  StateChangeTracker::UpdateRecordings();
+
+  result.status = RecordingTrashExecutorStatus::Trashed;
+  result.deletedRecordingFile = targetFile;
+  result.message = "Recording moved to the VDR trash.";
+  return result;
+}
+
+const char* RecordingTrashExecutorStatusName(RecordingTrashExecutorStatus status)
+{
+  switch (status) {
+    case RecordingTrashExecutorStatus::Trashed:
+      return "trashed";
+    case RecordingTrashExecutorStatus::Conflict:
+      return "conflict";
+    case RecordingTrashExecutorStatus::Blocked:
+      return "blocked";
+    case RecordingTrashExecutorStatus::NotFound:
+      return "not-found";
+    case RecordingTrashExecutorStatus::Failed:
+      return "failed";
+  }
+
+  return "failed";
+}

--- a/recordingtrashexecutor.cpp
+++ b/recordingtrashexecutor.cpp
@@ -3,6 +3,7 @@
 #include "changestatetracker.h"
 
 #include <cstring>
+#include <unistd.h>
 
 #include <vdr/menu.h>
 #include <vdr/recording.h>
@@ -23,6 +24,11 @@ std::string deletedFileName(const std::string& recordingFile)
   return std::string();
 }
 
+bool pathExists(const std::string& path)
+{
+  return !path.empty() && access(path.c_str(), F_OK) == 0;
+}
+
 }
 
 RecordingTrashExecutor::RecordingTrashExecutor(const RecordingTrashExecutionGate& gate)
@@ -37,6 +43,22 @@ RecordingTrashExecutorResult RecordingTrashExecutor::executeNormalCase(
 {
   RecordingTrashExecutorResult result;
   result.recordingFile = recordingFile;
+
+  const std::string targetFile = deletedFileName(recordingFile);
+  if (targetFile.empty()) {
+    result.status = RecordingTrashExecutorStatus::Blocked;
+    result.message = "Only active .rec recordings can be moved to the VDR trash.";
+    return result;
+  }
+
+  result.deletedRecordingFile = targetFile;
+
+  if (!pathExists(recordingFile) && pathExists(targetFile)) {
+    result.status = RecordingTrashExecutorStatus::AlreadyTrashed;
+    result.message = "Recording is already present in the VDR trash.";
+    return result;
+  }
+
   result.gate = gate.validate(recordingFile, expectedRevision, policy);
 
   if (result.gate.status == RecordingTrashExecutionGateStatus::Conflict) {
@@ -51,20 +73,25 @@ RecordingTrashExecutorResult RecordingTrashExecutor::executeNormalCase(
     return result;
   }
 
-  const std::string targetFile = deletedFileName(recordingFile);
-  if (targetFile.empty()) {
-    result.status = RecordingTrashExecutorStatus::Blocked;
-    result.message = "Only active .rec recordings can be moved to the VDR trash.";
-    return result;
-  }
-
   LOCK_TIMERS_WRITE;
   LOCK_RECORDINGS_WRITE;
 
   cRecording* recording = Recordings->GetByName(recordingFile.c_str());
   if (!recording) {
-    result.status = RecordingTrashExecutorStatus::NotFound;
-    result.message = "Recording disappeared before execution.";
+    if (!pathExists(recordingFile) && pathExists(targetFile)) {
+      result.status = RecordingTrashExecutorStatus::AlreadyTrashed;
+      result.message = "Recording is already present in the VDR trash.";
+    }
+    else {
+      result.status = RecordingTrashExecutorStatus::NotFound;
+      result.message = "Recording disappeared before execution.";
+    }
+    return result;
+  }
+
+  if (pathExists(targetFile)) {
+    result.status = RecordingTrashExecutorStatus::Conflict;
+    result.message = "The VDR trash target already exists.";
     return result;
   }
 
@@ -101,6 +128,12 @@ RecordingTrashExecutorResult RecordingTrashExecutor::executeNormalCase(
     return result;
   }
 
+  if (pathExists(recordingFile) || !pathExists(targetFile)) {
+    result.status = RecordingTrashExecutorStatus::Failed;
+    result.message = "Recording trash postcondition verification failed.";
+    return result;
+  }
+
   {
     LOCK_DELETEDRECORDINGS_WRITE;
     Recordings->Del(recording, false);
@@ -111,7 +144,6 @@ RecordingTrashExecutorResult RecordingTrashExecutor::executeNormalCase(
   StateChangeTracker::UpdateRecordings();
 
   result.status = RecordingTrashExecutorStatus::Trashed;
-  result.deletedRecordingFile = targetFile;
   result.message = "Recording moved to the VDR trash.";
   return result;
 }
@@ -121,6 +153,8 @@ const char* RecordingTrashExecutorStatusName(RecordingTrashExecutorStatus status
   switch (status) {
     case RecordingTrashExecutorStatus::Trashed:
       return "trashed";
+    case RecordingTrashExecutorStatus::AlreadyTrashed:
+      return "already-trashed";
     case RecordingTrashExecutorStatus::Conflict:
       return "conflict";
     case RecordingTrashExecutorStatus::Blocked:

--- a/recordingtrashexecutor.cpp
+++ b/recordingtrashexecutor.cpp
@@ -6,6 +6,7 @@
 
 #include <vdr/menu.h>
 #include <vdr/recording.h>
+#include <vdr/videodir.h>
 
 namespace {
 

--- a/recordingtrashexecutor.h
+++ b/recordingtrashexecutor.h
@@ -1,0 +1,42 @@
+#ifndef __RECORDINGTRASHEXECUTOR_H
+#define __RECORDINGTRASHEXECUTOR_H
+
+#include "recordingexecution.h"
+
+#include <string>
+
+enum class RecordingTrashExecutorStatus
+{
+  Trashed,
+  Conflict,
+  Blocked,
+  NotFound,
+  Failed
+};
+
+struct RecordingTrashExecutorResult
+{
+  RecordingTrashExecutorStatus status = RecordingTrashExecutorStatus::Failed;
+  std::string recordingFile;
+  std::string deletedRecordingFile;
+  std::string message;
+  RecordingTrashExecutionGateResult gate;
+};
+
+class RecordingTrashExecutor
+{
+public:
+  explicit RecordingTrashExecutor(const RecordingTrashExecutionGate& gate);
+
+  RecordingTrashExecutorResult executeNormalCase(
+    const std::string& recordingFile,
+    const RecordingMutationRevision& expectedRevision,
+    const RecordingMutationPolicy& policy) const;
+
+private:
+  const RecordingTrashExecutionGate& gate;
+};
+
+const char* RecordingTrashExecutorStatusName(RecordingTrashExecutorStatus status);
+
+#endif

--- a/recordingtrashexecutor.h
+++ b/recordingtrashexecutor.h
@@ -8,6 +8,7 @@
 enum class RecordingTrashExecutorStatus
 {
   Trashed,
+  AlreadyTrashed,
   Conflict,
   Blocked,
   NotFound,

--- a/recordingvalidate.cpp
+++ b/recordingvalidate.cpp
@@ -1,0 +1,139 @@
+#include "recordingvalidate.h"
+
+#include "recordinganalysis.h"
+#include "recordingexecution.h"
+#include "recordingmutation.h"
+#include "tools.h"
+
+#include <cxxtools/jsonserializer.h>
+
+#include <string>
+
+namespace {
+
+bool parseLongLong(const std::string& value, long long& result)
+{
+  if (value.empty())
+    return false;
+
+  try {
+    std::size_t parsed = 0;
+    result = std::stoll(value, &parsed, 10);
+    return parsed == value.size();
+  }
+  catch (...) {
+    return false;
+  }
+}
+
+std::vector<std::string> constraintNames(
+  const std::vector<RecordingConstraint>& constraints)
+{
+  std::vector<std::string> names;
+  for (RecordingConstraint constraint : constraints)
+    names.push_back(RecordingConstraintName(constraint));
+  return names;
+}
+
+}
+
+void RecordingTrashValidateResponder::reply(
+  std::ostream& out,
+  cxxtools::http::Request& request,
+  cxxtools::http::Reply& reply)
+{
+  QueryHandler::addHeader(reply);
+
+  if (request.method() == "OPTIONS") {
+    reply.addHeader("Allow", "POST");
+    reply.httpReturn(200, "OK");
+    return;
+  }
+
+  if (request.method() != "POST") {
+    reply.httpReturn(501, "Only POST method is supported by the /recordings/trash/validate service.");
+    return;
+  }
+
+  QueryHandler query("/recordings/trash/validate", request);
+  const std::string recordingFile = query.getBodyAsString("file");
+  const std::string recordingsStateText =
+    query.getBodyAsString("revision_recordings_state");
+  const std::string timersStateText =
+    query.getBodyAsString("revision_timers_state");
+
+  long long recordingsState = 0;
+  long long timersState = 0;
+
+  if (recordingFile.empty()) {
+    reply.httpReturn(400, "Recording file is missing.");
+    return;
+  }
+
+  if (!parseLongLong(recordingsStateText, recordingsState) ||
+      !parseLongLong(timersStateText, timersState)) {
+    reply.httpReturn(400, "Recording revision is missing or invalid.");
+    return;
+  }
+
+  RecordingMutationPolicy policy;
+  policy.allowRecordingHandlerStop = query.getBodyAsBool("allow_recording_handler_stop");
+  policy.allowReplayStop = query.getBodyAsBool("allow_replay_stop");
+  policy.allowLocalTimerStop = query.getBodyAsBool("allow_local_timer_stop");
+  policy.allowRemoteTimerStop = query.getBodyAsBool("allow_remote_timer_stop");
+
+  VdrRecordingLookup recordingLookup;
+  VdrRecordingReplayLookup replayLookup;
+  VdrRecordingHandlerLookup recordingHandlerLookup;
+  VdrRecordingLocalTimerLookup localTimerLookup;
+  VdrRecordingRemoteTimerLookup remoteTimerLookup;
+  VdrRecordingSearchTimerLookup searchTimerLookup;
+
+  RecordingTrashAnalyzer analyzer(
+    recordingLookup,
+    replayLookup,
+    recordingHandlerLookup,
+    localTimerLookup,
+    remoteTimerLookup,
+    searchTimerLookup);
+
+  RecordingMutationPlanner planner;
+  RecordingTrashExecutionGate gate(analyzer, planner);
+
+  RecordingMutationRevision expectedRevision;
+  expectedRevision.recordingFile = recordingFile;
+  expectedRevision.recordingsState = recordingsState;
+  expectedRevision.timersState = timersState;
+
+  const RecordingTrashExecutionGateResult result =
+    gate.validate(recordingFile, expectedRevision, policy);
+
+  reply.addHeader("Content-Type", "application/json; charset=utf-8");
+
+  cxxtools::JsonSerializer serializer(out);
+  serializer.serialize(
+    std::string(RecordingTrashExecutionGateStatusName(result.status)),
+    "status");
+  serializer.serialize(result.recordingFile, "recording_file");
+  serializer.serialize(constraintNames(result.blockers), "blockers");
+  serializer.serialize(result.warnings, "warnings");
+  serializer.serialize(
+    result.expectedRevision.recordingFile,
+    "expected_revision_recording_file");
+  serializer.serialize(
+    result.expectedRevision.recordingsState,
+    "expected_revision_recordings_state");
+  serializer.serialize(
+    result.expectedRevision.timersState,
+    "expected_revision_timers_state");
+  serializer.serialize(
+    result.currentRevision.recordingFile,
+    "current_revision_recording_file");
+  serializer.serialize(
+    result.currentRevision.recordingsState,
+    "current_revision_recordings_state");
+  serializer.serialize(
+    result.currentRevision.timersState,
+    "current_revision_timers_state");
+  serializer.finish();
+}

--- a/recordingvalidate.h
+++ b/recordingvalidate.h
@@ -1,0 +1,25 @@
+#ifndef __RECORDINGVALIDATE_H
+#define __RECORDINGVALIDATE_H
+
+#include <cxxtools/http/request.h>
+#include <cxxtools/http/reply.h>
+#include <cxxtools/http/responder.h>
+
+class RecordingTrashValidateResponder : public cxxtools::http::Responder
+{
+public:
+  explicit RecordingTrashValidateResponder(cxxtools::http::Service& service)
+    : cxxtools::http::Responder(service)
+  {
+  }
+
+  void reply(
+    std::ostream& out,
+    cxxtools::http::Request& request,
+    cxxtools::http::Reply& reply) override;
+};
+
+typedef cxxtools::http::CachedService<RecordingTrashValidateResponder>
+  RecordingTrashValidateService;
+
+#endif

--- a/serverthread.cpp
+++ b/serverthread.cpp
@@ -41,6 +41,7 @@ void cServerThread::Action(void)
   EventsService eventsService;
   RecordingsService recordingsService;
   RecordingTrashPreviewService recordingTrashPreviewService;
+  RecordingTrashValidateService recordingTrashValidateService;
   RemoteService remoteService;
   TimersService timersService;
   ChangeStateService changeStateService;
@@ -61,6 +62,7 @@ void cServerThread::Action(void)
   RestfulService* recordingsCut = new RestfulService("/recordings/cut", true, 1, recordings);
   RestfulService* recordingsMarks = new RestfulService("/recordings/marks", true, 1, recordings);
   RestfulService* recordingTrashPreview = new RestfulService("/recordings/trash/preview", true, 1, recordings);
+  RestfulService* recordingTrashValidate = new RestfulService("/recordings/trash/validate", true, 1, recordings);
   RestfulService* remote = new RestfulService("/remote", true, 1);
   RestfulService* timers = new RestfulService("/timers", true, 1);
   RestfulService* changeState = new RestfulService("/change-state", true, 1);
@@ -82,6 +84,7 @@ void cServerThread::Action(void)
   services->appendService(recordingsCut);
   services->appendService(recordingsMarks);
   services->appendService(recordingTrashPreview);
+  services->appendService(recordingTrashValidate);
   services->appendService(remote);
   services->appendService(timers);
   services->appendService(changeState);
@@ -96,6 +99,7 @@ void cServerThread::Action(void)
   server->addService(std::move(*channels->Regex()), channelsService);
   server->addService(std::move(*events->Regex()), eventsService);
   server->addService(std::move(*recordingTrashPreview->Regex()), recordingTrashPreviewService);
+  server->addService(std::move(*recordingTrashValidate->Regex()), recordingTrashValidateService);
   server->addService(std::move(*recordings->Regex()), recordingsService);
   server->addService(std::move(*remote->Regex()), remoteService);
   server->addService(std::move(*timers->Regex()), timersService);

--- a/serverthread.cpp
+++ b/serverthread.cpp
@@ -40,6 +40,7 @@ void cServerThread::Action(void)
   ChannelsService channelsService;
   EventsService eventsService;
   RecordingsService recordingsService;
+  RecordingTrashPreviewService recordingTrashPreviewService;
   RemoteService remoteService;
   TimersService timersService;
   ChangeStateService changeStateService;
@@ -59,6 +60,7 @@ void cServerThread::Action(void)
   RestfulService* recordings = new RestfulService("/recordings", true, 1);
   RestfulService* recordingsCut = new RestfulService("/recordings/cut", true, 1, recordings);
   RestfulService* recordingsMarks = new RestfulService("/recordings/marks", true, 1, recordings);
+  RestfulService* recordingTrashPreview = new RestfulService("/recordings/trash/preview", true, 1, recordings);
   RestfulService* remote = new RestfulService("/remote", true, 1);
   RestfulService* timers = new RestfulService("/timers", true, 1);
   RestfulService* changeState = new RestfulService("/change-state", true, 1);
@@ -79,6 +81,7 @@ void cServerThread::Action(void)
   services->appendService(recordings);
   services->appendService(recordingsCut);
   services->appendService(recordingsMarks);
+  services->appendService(recordingTrashPreview);
   services->appendService(remote);
   services->appendService(timers);
   services->appendService(changeState);
@@ -92,6 +95,7 @@ void cServerThread::Action(void)
   server->addService(std::move(*info->Regex()), infoService);
   server->addService(std::move(*channels->Regex()), channelsService);
   server->addService(std::move(*events->Regex()), eventsService);
+  server->addService(std::move(*recordingTrashPreview->Regex()), recordingTrashPreviewService);
   server->addService(std::move(*recordings->Regex()), recordingsService);
   server->addService(std::move(*remote->Regex()), remoteService);
   server->addService(std::move(*timers->Regex()), timersService);

--- a/serverthread.cpp
+++ b/serverthread.cpp
@@ -42,6 +42,7 @@ void cServerThread::Action(void)
   RecordingsService recordingsService;
   RecordingTrashPreviewService recordingTrashPreviewService;
   RecordingTrashValidateService recordingTrashValidateService;
+  RecordingTrashService recordingTrashService;
   RemoteService remoteService;
   TimersService timersService;
   ChangeStateService changeStateService;
@@ -63,6 +64,7 @@ void cServerThread::Action(void)
   RestfulService* recordingsMarks = new RestfulService("/recordings/marks", true, 1, recordings);
   RestfulService* recordingTrashPreview = new RestfulService("/recordings/trash/preview", true, 1, recordings);
   RestfulService* recordingTrashValidate = new RestfulService("/recordings/trash/validate", true, 1, recordings);
+  RestfulService* recordingTrash = new RestfulService("/recordings/trash", true, 1, recordings);
   RestfulService* remote = new RestfulService("/remote", true, 1);
   RestfulService* timers = new RestfulService("/timers", true, 1);
   RestfulService* changeState = new RestfulService("/change-state", true, 1);
@@ -85,6 +87,7 @@ void cServerThread::Action(void)
   services->appendService(recordingsMarks);
   services->appendService(recordingTrashPreview);
   services->appendService(recordingTrashValidate);
+  services->appendService(recordingTrash);
   services->appendService(remote);
   services->appendService(timers);
   services->appendService(changeState);
@@ -100,6 +103,7 @@ void cServerThread::Action(void)
   server->addService(std::move(*events->Regex()), eventsService);
   server->addService(std::move(*recordingTrashPreview->Regex()), recordingTrashPreviewService);
   server->addService(std::move(*recordingTrashValidate->Regex()), recordingTrashValidateService);
+  server->addService(std::move(*recordingTrash->Regex()), recordingTrashService);
   server->addService(std::move(*recordings->Regex()), recordingsService);
   server->addService(std::move(*remote->Regex()), remoteService);
   server->addService(std::move(*timers->Regex()), timersService);

--- a/serverthread.h
+++ b/serverthread.h
@@ -18,6 +18,7 @@
 #include "recordings.h"
 #include "recordingpreview.h"
 #include "recordingvalidate.h"
+#include "recordingtrash.h"
 #include "remote.h"
 #include "timers.h"
 #include "changestate.h"

--- a/serverthread.h
+++ b/serverthread.h
@@ -17,6 +17,7 @@
 #include "events.h"
 #include "recordings.h"
 #include "recordingpreview.h"
+#include "recordingvalidate.h"
 #include "remote.h"
 #include "timers.h"
 #include "changestate.h"

--- a/serverthread.h
+++ b/serverthread.h
@@ -16,6 +16,7 @@
 #include "channels.h"
 #include "events.h"
 #include "recordings.h"
+#include "recordingpreview.h"
 #include "remote.h"
 #include "timers.h"
 #include "changestate.h"


### PR DESCRIPTION
- **Add recording mutation domain foundation**
- **Implement recording trash planner foundation**
- **Build recording mutation foundation**
- **Fix Makefile regression from mutation build wiring**
- **Add recording analysis provider interfaces**
- **Implement recording lookup and replay analysis**
- **Model unknown recording handler analysis state**
- **Block trash planning on unknown handler state**
- **Build recording analysis foundation**
- **Add recording handler analysis provider**
- **Implement recording handler usage analysis**
- **Match upstream Makefile whitespace exactly**
- **Split local and remote timer analysis constraints**
- **Block trash planning on unknown local or remote timer state**
- **Add local recording timer analysis provider**
- **Implement local recording timer analysis**
- **Add remote recording timer analysis provider**
- **Implement remote recording timer analysis**
- **Add EPGSearch recording origin analysis provider**
- **Implement SearchTimer origin analysis**
- **Add recording trash preflight service model**
- **Implement recording trash preflight service**
- **Build recording trash preflight service**
- **Add recording trash preview HTTP service**
- **Implement recording trash preview HTTP service**
- **Register recording trash preview service header**
- **Register recording trash preview HTTP route**
- **Build recording trash preview HTTP service**
- **Add deterministic trash preflight state fingerprints**
- **Add recording trash execution gate model**
- **Implement recording trash execution gate**
- **Build recording trash execution gate**
- **Add recording trash validation HTTP service**
- **Implement recording trash validation HTTP service**
- **Register recording trash validation service header**
- **Register recording trash validation HTTP route**
- **Build recording trash validation HTTP service**
- **Add safe recording trash executor model**
- **Implement safe normal-case recording trash executor**
- **Build safe recording trash executor**
- **Include VDR video disk usage declaration**
- **Add recording trash HTTP service**
- **Implement recording trash HTTP service**
- **Register recording trash service header**
- **Register recording trash HTTP route**
- **Build recording trash HTTP service**
- **Keep recording trash Makefile wiring minimal**
- **Model idempotent recording trash results**
- **Harden recording trash postconditions and retries**
- **Return idempotent recording trash success**
- **Handle local recording timer marker in trash analysis**
- **Resolve recording timer markers against local timers first**
- **Do not classify local recording timers as remote**
- **Document safe native recording trash API**
