### PR TITLE
Add safe native recording trash and move workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingmoveanalysis.o recordingpreflight.o recordingmovepreflight.o recordingpreview.o recordingmovepreview.o recordingexecution.o recordingvalidate.o recordingtrashexecutor.o recordingtrash.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingmoveanalysis.o recordingpreflight.o recordingmovepreflight.o recordingpreview.o recordingmovepreview.o recordingexecution.o recordingmoveexecution.o recordingvalidate.o recordingmovevalidate.o recordingtrashexecutor.o recordingtrash.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n
@@ -72,7 +72,7 @@ $(I18Npot): $(wildcard *.cpp)
 $(I18Nmsgs): $(DESTDIR)$(LOCDIR)/%/LC_MESSAGES/vdr-$(PLUGIN).mo: $(PODIR)/%.mo
 	install -D -m644 $< $@
 
-.PHONY: i18n test-recording-move-plan test-recording-move-analysis test-recording-move-preflight
+.PHONY: i18n test-recording-move-plan test-recording-move-analysis test-recording-move-preflight test-recording-move-execution-gate
 i18n: $(I18Nmo) $(I18Npot)
 
 test-recording-move-plan:
@@ -98,6 +98,15 @@ test-recording-move-preflight:
 		tests/test_recording_move_preflight.cpp \
 		-o /tmp/test_recording_move_preflight
 	/tmp/test_recording_move_preflight
+
+test-recording-move-execution-gate:
+	$(CXX) -std=c++17 -Wall -Wextra \
+		recordingmutation.cpp \
+		recordingmoveanalysis.cpp \
+		recordingmoveexecution.cpp \
+		tests/test_recording_move_execution_gate.cpp \
+		-o /tmp/test_recording_move_execution_gate
+	/tmp/test_recording_move_execution_gate
 
 install-i18n: $(I18Nmsgs)
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ $(DEPFILE): Makefile
 
 PODIR     = po
 I18Npo    = $(wildcard $(PODIR)/*.po)
-I18Nmo    = $(addsuffix .mo, $(foreach file,$(I18Npo),$(basename $(file))))
-I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/, $(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo, $(notdir $(foreach file,$(I18Npo),$(basename $(file))))))
+I18Nmo    = $(addsuffix .mo, $(foreach file, $(I18Npo), $(basename $(file))))
+I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/, $(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo, $(notdir $(foreach file, $(I18Npo), $(basename $(file))))))
 I18Npot   = $(PODIR)/$(PLUGIN).pot
 
 %.mo: %.po
@@ -109,6 +109,7 @@ dist: $(I18Npo) clean
 	@cp -a * $(TMPDIR)/$(ARCHIVE)
 	@-rm -rf $(TMPDIR)/$(ARCHIVE)/debian
 	@tar czf $(PACKAGE).tgz -C $(TMPDIR) $(ARCHIVE)
+	@-rm -rf $(TMPDIR)/$(ARCHIVE)
 	@echo Distribution package created as $(PACKAGE).tgz
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o recordingvalidate.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o recordingvalidate.o recordingtrashexecutor.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o recordingvalidate.o recordingtrashexecutor.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o recordingvalidate.o recordingtrashexecutor.o recordingtrash.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n
@@ -55,8 +55,8 @@ $(DEPFILE): Makefile
 
 PODIR     = po
 I18Npo    = $(wildcard $(PODIR)/*.po)
-I18Nmo    = $(addsuffix .mo, $(foreach file, $(I18Npo), $(basename $(file))))
-I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/, $(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo, $(notdir $(foreach file, $(I18Npo), $(basename $(file))))))
+I18Nmo    = $(addsuffix .mo, $(foreach file,$(I18Npo),$(basename $(file))))
+I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/,$(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo,$(notdir $(foreach file,$(I18Npo),$(basename $(file))))))
 I18Npot   = $(PODIR)/$(PLUGIN).pot
 
 %.mo: %.po

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o recordingvalidate.o recordingtrashexecutor.o recordingtrash.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingmoveanalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o recordingvalidate.o recordingtrashexecutor.o recordingtrash.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n
@@ -55,8 +55,8 @@ $(DEPFILE): Makefile
 
 PODIR     = po
 I18Npo    = $(wildcard $(PODIR)/*.po)
-I18Nmo    = $(addsuffix .mo, $(foreach file, $(I18Npo), $(basename $(file))))
-I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/, $(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo, $(notdir $(foreach file, $(I18Npo), $(basename $(file))))))
+I18Nmo    = $(addsuffix .mo, $(foreach file,$(I18Npo),$(basename $(file))))
+I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/, $(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo, $(notdir $(foreach file,$(I18Npo),$(basename $(file))))))
 I18Npot   = $(PODIR)/$(PLUGIN).pot
 
 %.mo: %.po
@@ -72,7 +72,7 @@ $(I18Npot): $(wildcard *.cpp)
 $(I18Nmsgs): $(DESTDIR)$(LOCDIR)/%/LC_MESSAGES/vdr-$(PLUGIN).mo: $(PODIR)/%.mo
 	install -D -m644 $< $@
 
-.PHONY: i18n test-recording-move-plan
+.PHONY: i18n test-recording-move-plan test-recording-move-analysis
 i18n: $(I18Nmo) $(I18Npot)
 
 test-recording-move-plan:
@@ -81,6 +81,14 @@ test-recording-move-plan:
 		tests/test_recording_move_plan.cpp \
 		-o /tmp/test_recording_move_plan
 	/tmp/test_recording_move_plan
+
+test-recording-move-analysis:
+	$(CXX) -std=c++17 -Wall -Wextra \
+		recordingmutation.cpp \
+		recordingmoveanalysis.cpp \
+		tests/test_recording_move_analysis.cpp \
+		-o /tmp/test_recording_move_analysis
+	/tmp/test_recording_move_analysis
 
 install-i18n: $(I18Nmsgs)
 
@@ -101,7 +109,6 @@ dist: $(I18Npo) clean
 	@cp -a * $(TMPDIR)/$(ARCHIVE)
 	@-rm -rf $(TMPDIR)/$(ARCHIVE)/debian
 	@tar czf $(PACKAGE).tgz -C $(TMPDIR) $(ARCHIVE)
-	@-rm -rf $(TMPDIR)/$(ARCHIVE)
 	@echo Distribution package created as $(PACKAGE).tgz
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,15 @@ $(I18Npot): $(wildcard *.cpp)
 $(I18Nmsgs): $(DESTDIR)$(LOCDIR)/%/LC_MESSAGES/vdr-$(PLUGIN).mo: $(PODIR)/%.mo
 	install -D -m644 $< $@
 
-.PHONY: i18n
+.PHONY: i18n test-recording-move-plan
 i18n: $(I18Nmo) $(I18Npot)
+
+test-recording-move-plan:
+	$(CXX) -std=c++17 -Wall -Wextra \
+		recordingmutation.cpp \
+		tests/test_recording_move_plan.cpp \
+		-o /tmp/test_recording_move_plan
+	/tmp/test_recording_move_plan
 
 install-i18n: $(I18Nmsgs)
 

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ test-recording-move-analysis:
 test-recording-move-preflight:
 	$(CXX) -std=c++17 -Wall -Wextra \
 		recordingmutation.cpp \
+		recordinganalysis.cpp \
 		recordingmoveanalysis.cpp \
 		recordingpreflight.cpp \
 		tests/test_recording_move_preflight.cpp \

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,6 @@ dist: $(I18Npo) clean
 clean:
 	@-rm -f $(PODIR)/*.mo $(PODIR)/*.pot
 	@-rm -f $(OBJS) $(DEPFILE) *.so *.tgz core* *~ ._*
-
+	
 archive:
 	git archive --format=tar.gz --prefix=vdr-plugin-restfulapi-${VERSION}/ --output=../vdr-plugin-restfulapi-${VERSION}.tar.gz master

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingmoveanalysis.o recordingpreflight.o recordingmovepreflight.o recordingpreview.o recordingmovepreview.o recordingexecution.o recordingmoveexecution.o recordingvalidate.o recordingmovevalidate.o recordingtrashexecutor.o recordingtrash.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingmoveanalysis.o recordingpreflight.o recordingmovepreflight.o recordingpreview.o recordingmovepreview.o recordingexecution.o recordingmoveexecution.o recordingvalidate.o recordingmovevalidate.o recordingmoveexecutor.o recordingmove.o recordingtrashexecutor.o recordingtrash.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n
@@ -55,8 +55,8 @@ $(DEPFILE): Makefile
 
 PODIR     = po
 I18Npo    = $(wildcard $(PODIR)/*.po)
-I18Nmo    = $(addsuffix .mo, $(foreach file, $(I18Npo), $(basename $(file))))
-I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/, $(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo, $(notdir $(foreach file, $(I18Npo), $(basename $(file))))))
+I18Nmo    = $(addsuffix .mo, $(foreach file,$(I18Npo),$(basename $(file))))
+I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/,$(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo,$(notdir $(foreach file,$(I18Npo),$(basename $(file))))))
 I18Npot   = $(PODIR)/$(PLUGIN).pot
 
 %.mo: %.po
@@ -87,19 +87,3 @@ install-cfg: $(CFGS)
 	install -D $^ $(DESTDIR)$(PLGCONFDIR)/$^
 
 install: install-lib install-i18n install-cfg
-
-dist: $(I18Npo) clean
-	@-rm -rf $(TMPDIR)/$(ARCHIVE)
-	@mkdir $(TMPDIR)/$(ARCHIVE)
-	@cp -a * $(TMPDIR)/$(ARCHIVE)
-	@-rm -rf $(TMPDIR)/$(ARCHIVE)/debian
-	@tar czf $(PACKAGE).tgz -C $(TMPDIR) $(ARCHIVE)
-	@-rm -rf $(TMPDIR)/$(ARCHIVE)
-	@echo Distribution package created as $(PACKAGE).tgz
-
-clean:
-	@-rm -f $(PODIR)/*.mo $(PODIR)/*.pot
-	@-rm -f $(OBJS) $(DEPFILE) *.so *.tgz core* *~ ._*
-	
-archive:
-	git archive --format=tar.gz --prefix=vdr-plugin-restfulapi-${VERSION}/ --output=../vdr-plugin-restfulapi-${VERSION}.tar.gz master

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o recordingvalidate.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ $(DEPFILE): Makefile
 
 PODIR     = po
 I18Npo    = $(wildcard $(PODIR)/*.po)
-I18Nmo    = $(addsuffix .mo, $(foreach file, $(I18Npo), $(basename $(file))))
-I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/, $(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo, $(notdir $(foreach file, $(I18Npo), $(basename $(file))))))
+I18Nmo    = $(addsuffix .mo, $(foreach file,$(I18Npo),$(basename $(file))))
+I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/, $(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo, $(notdir $(foreach file,$(I18Npo),$(basename $(file))))))
 I18Npot   = $(PODIR)/$(PLUGIN).pot
 
 %.mo: %.po
@@ -72,7 +72,7 @@ $(I18Npot): $(wildcard *.cpp)
 $(I18Nmsgs): $(DESTDIR)$(LOCDIR)/%/LC_MESSAGES/vdr-$(PLUGIN).mo: $(PODIR)/%.mo
 	install -D -m644 $< $@
 
-.PHONY: i18n test-recording-move-plan test-recording-move-analysis
+.PHONY: i18n test-recording-move-plan test-recording-move-analysis test-recording-move-preflight
 i18n: $(I18Nmo) $(I18Npot)
 
 test-recording-move-plan:
@@ -89,6 +89,15 @@ test-recording-move-analysis:
 		tests/test_recording_move_analysis.cpp \
 		-o /tmp/test_recording_move_analysis
 	/tmp/test_recording_move_analysis
+
+test-recording-move-preflight:
+	$(CXX) -std=c++17 -Wall -Wextra \
+		recordingmutation.cpp \
+		recordingmoveanalysis.cpp \
+		recordingpreflight.cpp \
+		tests/test_recording_move_preflight.cpp \
+		-o /tmp/test_recording_move_preflight
+	/tmp/test_recording_move_preflight
 
 install-i18n: $(I18Nmsgs)
 
@@ -109,7 +118,6 @@ dist: $(I18Npo) clean
 	@cp -a * $(TMPDIR)/$(ARCHIVE)
 	@-rm -rf $(TMPDIR)/$(ARCHIVE)/debian
 	@tar czf $(PACKAGE).tgz -C $(TMPDIR) $(ARCHIVE)
-	@-rm -rf $(TMPDIR)/$(ARCHIVE)
 	@echo Distribution package created as $(PACKAGE).tgz
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ $(DEPFILE): Makefile
 
 PODIR     = po
 I18Npo    = $(wildcard $(PODIR)/*.po)
-I18Nmo    = $(addsuffix .mo, $(foreach file,$(I18Npo),$(basename $(file))))
-I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/,$(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo,$(notdir $(foreach file,$(I18Npo),$(basename $(file))))))
+I18Nmo    = $(addsuffix .mo, $(foreach file, $(I18Npo), $(basename $(file))))
+I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/, $(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo, $(notdir $(foreach file, $(I18Npo), $(basename $(file))))))
 I18Npot   = $(PODIR)/$(PLUGIN).pot
 
 %.mo: %.po

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingmoveanalysis.o recordingpreflight.o recordingmovepreflight.o recordingpreview.o recordingexecution.o recordingvalidate.o recordingtrashexecutor.o recordingtrash.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingmoveanalysis.o recordingpreflight.o recordingmovepreflight.o recordingpreview.o recordingmovepreview.o recordingexecution.o recordingvalidate.o recordingtrashexecutor.o recordingtrash.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ $(DEPFILE): Makefile
 
 PODIR     = po
 I18Npo    = $(wildcard $(PODIR)/*.po)
-I18Nmo    = $(addsuffix .mo, $(foreach file,$(I18Npo),$(basename $(file))))
-I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/,$(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo,$(notdir $(foreach file,$(I18Npo),$(basename $(file))))))
+I18Nmo    = $(addsuffix .mo, $(foreach file, $(I18Npo), $(basename $(file))))
+I18Nmsgs  = $(addprefix $(DESTDIR)$(LOCDIR)/, $(addsuffix /LC_MESSAGES/vdr-$(PLUGIN).mo, $(notdir $(foreach file, $(I18Npo), $(basename $(file))))))
 I18Npot   = $(PODIR)/$(PLUGIN).pot
 
 %.mo: %.po
@@ -87,3 +87,19 @@ install-cfg: $(CFGS)
 	install -D $^ $(DESTDIR)$(PLGCONFDIR)/$^
 
 install: install-lib install-i18n install-cfg
+
+dist: $(I18Npo) clean
+	@-rm -rf $(TMPDIR)/$(ARCHIVE)
+	@mkdir $(TMPDIR)/$(ARCHIVE)
+	@cp -a * $(TMPDIR)/$(ARCHIVE)
+	@-rm -rf $(TMPDIR)/$(ARCHIVE)/debian
+	@tar czf $(PACKAGE).tgz -C $(TMPDIR) $(ARCHIVE)
+	@-rm -rf $(TMPDIR)/$(ARCHIVE)
+	@echo Distribution package created as $(PACKAGE).tgz
+
+clean:
+	@-rm -f $(PODIR)/*.mo $(PODIR)/*.pot
+	@-rm -f $(OBJS) $(DEPFILE) *.so *.tgz core* *~ ._*
+
+archive:
+	git archive --format=tar.gz --prefix=vdr-plugin-restfulapi-${VERSION}/ --output=../vdr-plugin-restfulapi-${VERSION}.tar.gz master

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingpreflight.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LIBS += $(shell pkg-config --libs Magick++)
 CXXFLAGS += -DUSE_LIBMAGICKPLUSPLUS
 endif
 
-OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingmoveanalysis.o recordingpreflight.o recordingpreview.o recordingexecution.o recordingvalidate.o recordingtrashexecutor.o recordingtrash.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
+OBJS = $(PLUGIN).o serverthread.o tools.o info.o searchtimers.o channels.o events.o recordings.o recordingmutation.o recordinganalysis.o recordingmoveanalysis.o recordingpreflight.o recordingmovepreflight.o recordingpreview.o recordingexecution.o recordingvalidate.o recordingtrashexecutor.o recordingtrash.o remote.o timers.o changestate.o eventsstreamthread.o changestatetracker.o scraper2vdr.o statusmonitor.o osd.o jsonparser.o epgsearch.o wirbelscan.o webapp.o femon.o
 CFGS = API.html
 
 all: $(SOFILE) i18n
@@ -93,9 +93,8 @@ test-recording-move-analysis:
 test-recording-move-preflight:
 	$(CXX) -std=c++17 -Wall -Wextra \
 		recordingmutation.cpp \
-		recordinganalysis.cpp \
 		recordingmoveanalysis.cpp \
-		recordingpreflight.cpp \
+		recordingmovepreflight.cpp \
 		tests/test_recording_move_preflight.cpp \
 		-o /tmp/test_recording_move_preflight
 	/tmp/test_recording_move_preflight

--- a/RECORDING_MOVE_API.md
+++ b/RECORDING_MOVE_API.md
@@ -1,0 +1,198 @@
+# Safe Native Recording Move API
+
+This document describes the safe recording move workflow implemented by the RESTfulAPI plugin.
+
+The implementation follows native VDR behavior. It does not stop playback, stop recordings, modify timers, cancel recording handler operations, or bypass VDR recording list updates.
+
+## Workflow
+
+Recording move uses a three-step optimistic-locking workflow:
+
+1. Preview the operation and obtain state fingerprints.
+2. Optionally validate that the fingerprints are still current.
+3. Execute the operation with the confirmed fingerprints.
+
+Preview and validation are read-only. They do not modify the recording, timers, playback state, filesystem, or VDR recording lists.
+
+## Path contract
+
+Both `file` and `target_file` are complete native VDR filesystem identities.
+
+Example:
+
+```text
+/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec
+```
+
+The target must be absolute, must differ from the source, and must not already exist in the filesystem or VDR recording list.
+
+## Preview
+
+```http
+POST /recordings/move/preview.json
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+  "file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "target_file": "/srv/vdr/video/Archive/Example/2026-07-14.08.53.3-0.rec"
+}
+```
+
+Executable response:
+
+```json
+{
+  "executable": true,
+  "recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "target_file": "/srv/vdr/video/Archive/Example/2026-07-14.08.53.3-0.rec",
+  "constraints": [],
+  "blockers": [],
+  "warnings": [],
+  "steps": [
+    "move-recording",
+    "refresh-recordings",
+    "notify-change"
+  ],
+  "revision_recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "revision_target_file": "/srv/vdr/video/Archive/Example/2026-07-14.08.53.3-0.rec",
+  "revision_recordings_state": 123456789,
+  "revision_timers_state": 987654321
+}
+```
+
+## Validate
+
+```http
+POST /recordings/move/validate.json
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+  "file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "target_file": "/srv/vdr/video/Archive/Example/2026-07-14.08.53.3-0.rec",
+  "revision_recordings_state": "123456789",
+  "revision_timers_state": "987654321"
+}
+```
+
+Validation status values:
+
+- `ready`: source, target, recording state, and timer state still match the preview revision.
+- `conflict`: source, target, replay, handler, or timer state changed after preview.
+- `blocked`: the current state or policy does not allow execution.
+
+## Execute
+
+```http
+POST /recordings/move.json
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+  "file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "target_file": "/srv/vdr/video/Archive/Example/2026-07-14.08.53.3-0.rec",
+  "revision_recordings_state": "123456789",
+  "revision_timers_state": "987654321"
+}
+```
+
+Successful response:
+
+```json
+{
+  "status": "moved",
+  "recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "target_file": "/srv/vdr/video/Archive/Example/2026-07-14.08.53.3-0.rec",
+  "message": "Recording moved to the requested target."
+}
+```
+
+Idempotent retry after the source has already been moved to the requested target:
+
+```json
+{
+  "status": "already-moved",
+  "recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "target_file": "/srv/vdr/video/Archive/Example/2026-07-14.08.53.3-0.rec",
+  "message": "Recording is already present at the requested target."
+}
+```
+
+## Protected states
+
+The operation is blocked when safety cannot be established or VDR is actively using the recording:
+
+- `replay-active`
+- `recording-handler-busy`
+- `local-timer-active`
+- `remote-timer-active`
+- `unknown-recording-handler-state`
+- `unknown-local-timer-state`
+- `unknown-remote-timer-state`
+- `unknown-search-timer-state`
+
+Move-specific blockers include:
+
+- `move-target-missing`
+- `move-target-invalid`
+- `move-target-same-as-source`
+- `move-target-exists`
+
+The execution endpoint does not automatically resolve these states.
+
+## Execution behavior
+
+The executor:
+
+1. Revalidates the optimistic-locking revision.
+2. Acquires VDR timer and recording write locks.
+3. Rechecks source, target, replay, handler, recording control, and timer association.
+4. Uses the native VDR directory move helper.
+5. Verifies that the source disappeared and the target exists.
+6. Replaces the source identity with the target identity in the VDR recording list.
+7. Runs the native `recordingaction rename` hook.
+8. Forces video disk usage refresh and recording change notification.
+
+## HTTP status codes
+
+| Status | Meaning |
+|---|---|
+| `200` | The recording was moved or is already present at the requested target. |
+| `400` | Source, target, or required revision values are missing or invalid. |
+| `404` | The source recording disappeared before execution. |
+| `409` | Source, target, recording, replay, handler, or timer state changed after preview. |
+| `423` | The operation is blocked by the current VDR state or policy. |
+| `500` | The native VDR mutation or postcondition verification failed. |
+| `501` | The requested HTTP method is not supported. |
+
+## Verified integration behavior
+
+The following cases were verified against a running VDR installation on July 15, 2026:
+
+- preview: `200`, executable, no filesystem mutation
+- validate: `200 ready`, expected and current revisions identical
+- missing revision: `400`
+- stale revision: `409`
+- unsupported method: `501`
+- completed 285 MB recording: `200 moved`
+- source directory removed and target directory present
+- old VDR recording identity absent and new identity present
+- native directory creation and rename logged by VDR
+- native `vdr-recordingaction rename` hook executed
+- immediate identical retry: `200 already-moved`
+- reverse move through the same preview, validate, and execute workflow: `200 moved`
+- final VDR recording list restored to the original identity
+
+## Design boundary
+
+This API moves a recording to one explicit native VDR filesystem identity. It is not a generic file manager, does not copy recordings, and does not silently stop active VDR operations.

--- a/RECORDING_TRASH_API.md
+++ b/RECORDING_TRASH_API.md
@@ -1,0 +1,193 @@
+# Safe Native Recording Trash API
+
+This document describes the recording trash workflow implemented by the RESTfulAPI plugin.
+
+The implementation deliberately follows native VDR behavior. It does not introduce a separate long-lived trash store and it does not automatically stop playback, stop recordings, delete timers, or cancel VDR handler operations.
+
+## Native VDR semantics
+
+A successful trash operation normally changes the recording directory from:
+
+```text
+/path/to/recording.rec
+```
+
+to:
+
+```text
+/path/to/recording.del
+```
+
+VDR may permanently remove the `.del` directory later during its regular cleanup. Therefore, `already-trashed` is only a temporary idempotent state while the native `.del` directory still exists. Once both `.rec` and `.del` are gone, the recording is no longer available.
+
+## Workflow
+
+Recording trash uses a three-step optimistic-locking workflow:
+
+1. Preview the operation and obtain state fingerprints.
+2. Optionally validate that the fingerprints are still current.
+3. Execute the operation with the confirmed fingerprints.
+
+Preview and validation are read-only. They do not modify the recording, timers, playback state, or VDR recording lists.
+
+## Preview
+
+```http
+POST /recordings/trash/preview.json
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+  "file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec"
+}
+```
+
+Executable response:
+
+```json
+{
+  "executable": true,
+  "recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "constraints": [],
+  "blockers": [],
+  "warnings": [],
+  "steps": [
+    "trash-recording",
+    "refresh-recordings",
+    "notify-change"
+  ],
+  "revision_recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "revision_recordings_state": 123456789,
+  "revision_timers_state": 987654321
+}
+```
+
+Blocked response example:
+
+```json
+{
+  "executable": false,
+  "recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "constraints": [
+    "local-timer-active"
+  ],
+  "blockers": [
+    "local-timer-active"
+  ],
+  "warnings": [],
+  "steps": [],
+  "revision_recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "revision_recordings_state": 123456789,
+  "revision_timers_state": 987654321
+}
+```
+
+## Validate
+
+```http
+POST /recordings/trash/validate.json
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+  "file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "revision_recordings_state": "123456789",
+  "revision_timers_state": "987654321"
+}
+```
+
+Validation status values:
+
+- `ready`: the recording is still executable with this revision.
+- `conflict`: recording, replay, handler, or timer state changed after preview.
+- `blocked`: the current state or policy does not allow execution.
+
+## Execute
+
+```http
+POST /recordings/trash.json
+Content-Type: application/json
+```
+
+Request:
+
+```json
+{
+  "file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "revision_recordings_state": "123456789",
+  "revision_timers_state": "987654321"
+}
+```
+
+Successful response:
+
+```json
+{
+  "status": "trashed",
+  "recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "deleted_recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.del",
+  "message": "Recording moved to the VDR trash."
+}
+```
+
+Immediate idempotent retry while `.del` still exists:
+
+```json
+{
+  "status": "already-trashed",
+  "recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.rec",
+  "deleted_recording_file": "/srv/vdr/video/Example/2026-07-14.08.53.3-0.del",
+  "message": "Recording is already present in the VDR trash."
+}
+```
+
+## Protected states
+
+The operation is blocked when safety cannot be established or VDR is actively using the recording:
+
+- `replay-active`
+- `recording-handler-busy`
+- `local-timer-active`
+- `remote-timer-active`
+- `unknown-recording-handler-state`
+- `unknown-local-timer-state`
+- `unknown-remote-timer-state`
+- `unknown-search-timer-state`
+
+The execution endpoint does not automatically resolve these states.
+
+## HTTP status codes
+
+| Status | Meaning |
+|---|---|
+| `200` | The recording was trashed or is already in VDR's native deleted state. |
+| `400` | The recording file or required revision values are missing or invalid. |
+| `404` | The recording is no longer present. |
+| `409` | Recording or timer state changed after preview. |
+| `423` | The operation is blocked by the current VDR state or policy. |
+| `500` | The native VDR mutation or postcondition verification failed. |
+| `501` | The requested HTTP method is not supported. |
+
+## Verified integration behavior
+
+The following cases were verified against a running VDR installation:
+
+- normal completed recording: `200 trashed`
+- immediate identical retry: `200 already-trashed`
+- active local recording: `423`, recording and timer remain active
+- active replay: `423`, recording remains present and replay is not stopped
+- stale revision: `409`
+- missing revision: `400`
+- unsupported method: `501`
+- preview: no filesystem mutation
+- successful execution: `.rec` becomes `.del` and VDR remains active
+
+## Design boundary
+
+This API models native VDR deletion. It is not a separate VDR-Suite recycle bin and does not guarantee a restore window. VDR controls when native `.del` recordings are permanently cleaned up.

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -32,11 +32,26 @@ bool VdrRecordingReplayLookup::isReplaying(const std::string& recordingFile) con
   return nowReplaying && std::strcmp(nowReplaying, recordingFile.c_str()) == 0;
 }
 
+RecordingHandlerLookupResult VdrRecordingHandlerLookup::getUsage(
+  const std::string& recordingFile) const
+{
+  RecordingHandlerLookupResult result;
+
+  if (recordingFile.empty())
+    return result;
+
+  result.known = true;
+  result.busy = RecordingsHandler.GetUsage(recordingFile.c_str()) != ruNone;
+  return result;
+}
+
 RecordingTrashAnalyzer::RecordingTrashAnalyzer(
   const IRecordingLookup& recordingLookup,
-  const IRecordingReplayLookup& replayLookup)
+  const IRecordingReplayLookup& replayLookup,
+  const IRecordingHandlerLookup& recordingHandlerLookup)
   : recordingLookup(recordingLookup),
-    replayLookup(replayLookup)
+    replayLookup(replayLookup),
+    recordingHandlerLookup(recordingHandlerLookup)
 {
 }
 
@@ -61,7 +76,14 @@ RecordingMutationAnalysis RecordingTrashAnalyzer::analyze(
   if (replayLookup.isReplaying(recording.recordingFile))
     analysis.constraints.push_back(RecordingConstraint::ReplayActive);
 
-  analysis.constraints.push_back(RecordingConstraint::UnknownRecordingHandlerState);
+  const RecordingHandlerLookupResult handlerUsage =
+    recordingHandlerLookup.getUsage(recording.recordingFile);
+
+  if (!handlerUsage.known)
+    analysis.constraints.push_back(RecordingConstraint::UnknownRecordingHandlerState);
+  else if (handlerUsage.busy)
+    analysis.constraints.push_back(RecordingConstraint::RecordingHandlerBusy);
+
   analysis.constraints.push_back(RecordingConstraint::UnknownTimerState);
   analysis.constraints.push_back(RecordingConstraint::UnknownSearchTimerState);
 

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -6,6 +6,70 @@
 #include <vdr/menu.h>
 #include <vdr/recording.h>
 
+namespace {
+
+bool parsePositiveInteger(const std::string& value, int& result)
+{
+  try {
+    std::size_t parsed = 0;
+    const long number = std::stol(value, &parsed, 10);
+    if (parsed != value.size() || number < 0 || number > std::numeric_limits<int>::max())
+      return false;
+    result = static_cast<int>(number);
+    return true;
+  }
+  catch (...) {
+    return false;
+  }
+}
+
+bool parseSearchTimerId(const char* aux, bool& present, int& searchTimerId)
+{
+  present = false;
+  searchTimerId = -1;
+
+  if (!aux || !*aux)
+    return true;
+
+  const std::string value(aux);
+  const std::string openTag = "<s-id>";
+  const std::string closeTag = "</s-id>";
+  const std::string::size_type begin = value.find(openTag);
+
+  if (begin == std::string::npos)
+    return true;
+
+  const std::string::size_type contentBegin = begin + openTag.size();
+  const std::string::size_type end = value.find(closeTag, contentBegin);
+  if (end == std::string::npos || end == contentBegin)
+    return false;
+
+  const std::string idText = value.substr(contentBegin, end - contentBegin);
+  if (!parsePositiveInteger(idText, searchTimerId))
+    return false;
+
+  present = true;
+  return true;
+}
+
+bool parseRemoteTimerId(
+  const std::string& value,
+  int& timerId,
+  std::string& remote)
+{
+  const std::string::size_type separator = value.find('@');
+  if (separator == std::string::npos || separator == 0 || separator + 1 >= value.size())
+    return false;
+
+  if (!parsePositiveInteger(value.substr(0, separator), timerId) || timerId <= 0)
+    return false;
+
+  remote = value.substr(separator + 1);
+  return !remote.empty();
+}
+
+}
+
 RecordingLookupResult VdrRecordingLookup::find(const std::string& recordingFile) const
 {
   RecordingLookupResult result;
@@ -75,24 +139,7 @@ RecordingRemoteTimerLookupResult VdrRecordingRemoteTimerLookup::findActive(
     return result;
   }
 
-  const std::string value(timerId);
-  const std::string::size_type separator = value.find('@');
-  if (separator == std::string::npos || separator == 0 || separator + 1 >= value.size())
-    return result;
-
-  try {
-    std::size_t parsed = 0;
-    const long id = std::stol(value.substr(0, separator), &parsed, 10);
-    if (parsed != separator || id <= 0 || id > std::numeric_limits<int>::max())
-      return result;
-    result.timerId = static_cast<int>(id);
-  }
-  catch (...) {
-    return result;
-  }
-
-  result.remote = value.substr(separator + 1);
-  if (result.remote.empty())
+  if (!parseRemoteTimerId(timerId, result.timerId, result.remote))
     return result;
 
   LOCK_TIMERS_READ;
@@ -105,17 +152,63 @@ RecordingRemoteTimerLookupResult VdrRecordingRemoteTimerLookup::findActive(
   return result;
 }
 
+RecordingSearchTimerLookupResult VdrRecordingSearchTimerLookup::findOrigin(
+  const std::string& recordingFile) const
+{
+  RecordingSearchTimerLookupResult result;
+
+  if (recordingFile.empty())
+    return result;
+
+  LOCK_TIMERS_READ;
+
+  const cTimer* timer = nullptr;
+  if (cRecordControl* recordControl = cRecordControls::GetRecordControl(recordingFile.c_str()))
+    timer = recordControl->Timer();
+
+  if (!timer) {
+    const cString timerIdText = GetRecordingTimerId(recordingFile.c_str());
+    const char* timerId = *timerIdText;
+
+    if (!timerId || !*timerId) {
+      result.known = true;
+      return result;
+    }
+
+    int id = 0;
+    std::string remote;
+    if (!parseRemoteTimerId(timerId, id, remote))
+      return result;
+
+    timer = Timers->GetById(id, remote.c_str());
+    if (!timer)
+      return result;
+  }
+
+  bool present = false;
+  int searchTimerId = -1;
+  if (!parseSearchTimerId(timer->Aux(), present, searchTimerId))
+    return result;
+
+  result.known = true;
+  result.searchTimerRecording = present;
+  result.searchTimerId = present ? searchTimerId : -1;
+  return result;
+}
+
 RecordingTrashAnalyzer::RecordingTrashAnalyzer(
   const IRecordingLookup& recordingLookup,
   const IRecordingReplayLookup& replayLookup,
   const IRecordingHandlerLookup& recordingHandlerLookup,
   const IRecordingLocalTimerLookup& localTimerLookup,
-  const IRecordingRemoteTimerLookup& remoteTimerLookup)
+  const IRecordingRemoteTimerLookup& remoteTimerLookup,
+  const IRecordingSearchTimerLookup& searchTimerLookup)
   : recordingLookup(recordingLookup),
     replayLookup(replayLookup),
     recordingHandlerLookup(recordingHandlerLookup),
     localTimerLookup(localTimerLookup),
-    remoteTimerLookup(remoteTimerLookup)
+    remoteTimerLookup(remoteTimerLookup),
+    searchTimerLookup(searchTimerLookup)
 {
 }
 
@@ -164,7 +257,13 @@ RecordingMutationAnalysis RecordingTrashAnalyzer::analyze(
   else if (remoteTimer.active)
     analysis.constraints.push_back(RecordingConstraint::RemoteTimerActive);
 
-  analysis.constraints.push_back(RecordingConstraint::UnknownSearchTimerState);
+  const RecordingSearchTimerLookupResult searchTimer =
+    searchTimerLookup.findOrigin(recording.recordingFile);
+
+  if (!searchTimer.known)
+    analysis.constraints.push_back(RecordingConstraint::UnknownSearchTimerState);
+  else if (searchTimer.searchTimerRecording)
+    analysis.constraints.push_back(RecordingConstraint::SearchTimerRecording);
 
   return analysis;
 }

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -45,13 +45,28 @@ RecordingHandlerLookupResult VdrRecordingHandlerLookup::getUsage(
   return result;
 }
 
+RecordingLocalTimerLookupResult VdrRecordingLocalTimerLookup::findActive(
+  const std::string& recordingFile) const
+{
+  RecordingLocalTimerLookupResult result;
+
+  if (recordingFile.empty())
+    return result;
+
+  result.known = true;
+  result.active = cRecordControls::GetRecordControl(recordingFile.c_str()) != nullptr;
+  return result;
+}
+
 RecordingTrashAnalyzer::RecordingTrashAnalyzer(
   const IRecordingLookup& recordingLookup,
   const IRecordingReplayLookup& replayLookup,
-  const IRecordingHandlerLookup& recordingHandlerLookup)
+  const IRecordingHandlerLookup& recordingHandlerLookup,
+  const IRecordingLocalTimerLookup& localTimerLookup)
   : recordingLookup(recordingLookup),
     replayLookup(replayLookup),
-    recordingHandlerLookup(recordingHandlerLookup)
+    recordingHandlerLookup(recordingHandlerLookup),
+    localTimerLookup(localTimerLookup)
 {
 }
 
@@ -84,7 +99,15 @@ RecordingMutationAnalysis RecordingTrashAnalyzer::analyze(
   else if (handlerUsage.busy)
     analysis.constraints.push_back(RecordingConstraint::RecordingHandlerBusy);
 
-  analysis.constraints.push_back(RecordingConstraint::UnknownTimerState);
+  const RecordingLocalTimerLookupResult localTimer =
+    localTimerLookup.findActive(recording.recordingFile);
+
+  if (!localTimer.known)
+    analysis.constraints.push_back(RecordingConstraint::UnknownLocalTimerState);
+  else if (localTimer.active)
+    analysis.constraints.push_back(RecordingConstraint::LocalTimerActive);
+
+  analysis.constraints.push_back(RecordingConstraint::UnknownRemoteTimerState);
   analysis.constraints.push_back(RecordingConstraint::UnknownSearchTimerState);
 
   return analysis;

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -1,7 +1,10 @@
 #include "recordinganalysis.h"
 
+#include <cstdint>
 #include <cstring>
 #include <limits>
+#include <sstream>
+#include <sys/stat.h>
 
 #include <vdr/menu.h>
 #include <vdr/recording.h>
@@ -66,6 +69,59 @@ bool parseRemoteTimerId(
 
   remote = value.substr(separator + 1);
   return !remote.empty();
+}
+
+long long fingerprint(const std::string& value)
+{
+  std::uint64_t hash = 1469598103934665603ULL;
+  for (unsigned char character : value) {
+    hash ^= character;
+    hash *= 1099511628211ULL;
+  }
+  return static_cast<long long>(hash & 0x7FFFFFFFFFFFFFFFULL);
+}
+
+long long recordingFingerprint(const std::string& recordingFile, bool found)
+{
+  std::ostringstream state;
+  state << recordingFile << '|';
+  state << (found ? "found" : "missing");
+
+  struct stat fileState;
+  if (found && stat(recordingFile.c_str(), &fileState) == 0) {
+    state << '|' << static_cast<unsigned long long>(fileState.st_dev);
+    state << '|' << static_cast<unsigned long long>(fileState.st_ino);
+    state << '|' << static_cast<long long>(fileState.st_mtime);
+    state << '|' << static_cast<long long>(fileState.st_ctime);
+  }
+  else if (found) {
+    state << "|stat-unavailable";
+  }
+
+  return fingerprint(state.str());
+}
+
+long long timerFingerprint(
+  bool replaying,
+  const RecordingHandlerLookupResult& handlerUsage,
+  const RecordingLocalTimerLookupResult& localTimer,
+  const RecordingRemoteTimerLookupResult& remoteTimer,
+  const RecordingSearchTimerLookupResult& searchTimer)
+{
+  std::ostringstream state;
+  state << "replay=" << replaying;
+  state << "|handler-known=" << handlerUsage.known;
+  state << "|handler-busy=" << handlerUsage.busy;
+  state << "|local-known=" << localTimer.known;
+  state << "|local-active=" << localTimer.active;
+  state << "|remote-known=" << remoteTimer.known;
+  state << "|remote-active=" << remoteTimer.active;
+  state << "|remote-id=" << remoteTimer.timerId;
+  state << "|remote=" << remoteTimer.remote;
+  state << "|search-known=" << searchTimer.known;
+  state << "|search-recording=" << searchTimer.searchTimerRecording;
+  state << "|search-id=" << searchTimer.searchTimerId;
+  return fingerprint(state.str());
 }
 
 }
@@ -221,6 +277,7 @@ RecordingMutationAnalysis RecordingTrashAnalyzer::analyze(
   analysis.revision.recordingFile = recordingFile;
 
   const RecordingLookupResult recording = recordingLookup.find(recordingFile);
+  analysis.revision.recordingsState = recordingFingerprint(recordingFile, recording.found);
 
   if (!recording.found) {
     analysis.constraints.push_back(RecordingConstraint::RecordingMissing);
@@ -229,8 +286,10 @@ RecordingMutationAnalysis RecordingTrashAnalyzer::analyze(
 
   analysis.recordingFile = recording.recordingFile;
   analysis.revision.recordingFile = recording.recordingFile;
+  analysis.revision.recordingsState = recordingFingerprint(recording.recordingFile, true);
 
-  if (replayLookup.isReplaying(recording.recordingFile))
+  const bool replaying = replayLookup.isReplaying(recording.recordingFile);
+  if (replaying)
     analysis.constraints.push_back(RecordingConstraint::ReplayActive);
 
   const RecordingHandlerLookupResult handlerUsage =
@@ -264,6 +323,13 @@ RecordingMutationAnalysis RecordingTrashAnalyzer::analyze(
     analysis.constraints.push_back(RecordingConstraint::UnknownSearchTimerState);
   else if (searchTimer.searchTimerRecording)
     analysis.constraints.push_back(RecordingConstraint::SearchTimerRecording);
+
+  analysis.revision.timersState = timerFingerprint(
+    replaying,
+    handlerUsage,
+    localTimer,
+    remoteTimer,
+    searchTimer);
 
   return analysis;
 }

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -1,0 +1,69 @@
+#include "recordinganalysis.h"
+
+#include <cstring>
+
+#include <vdr/menu.h>
+#include <vdr/recording.h>
+
+RecordingLookupResult VdrRecordingLookup::find(const std::string& recordingFile) const
+{
+  RecordingLookupResult result;
+
+  if (recordingFile.empty())
+    return result;
+
+  LOCK_RECORDINGS_READ;
+  const cRecording* recording = Recordings->GetByName(recordingFile.c_str());
+
+  if (!recording)
+    return result;
+
+  result.found = true;
+  result.recordingFile = recording->FileName();
+  return result;
+}
+
+bool VdrRecordingReplayLookup::isReplaying(const std::string& recordingFile) const
+{
+  if (recordingFile.empty())
+    return false;
+
+  const char* nowReplaying = cReplayControl::NowReplaying();
+  return nowReplaying && std::strcmp(nowReplaying, recordingFile.c_str()) == 0;
+}
+
+RecordingTrashAnalyzer::RecordingTrashAnalyzer(
+  const IRecordingLookup& recordingLookup,
+  const IRecordingReplayLookup& replayLookup)
+  : recordingLookup(recordingLookup),
+    replayLookup(replayLookup)
+{
+}
+
+RecordingMutationAnalysis RecordingTrashAnalyzer::analyze(
+  const std::string& recordingFile) const
+{
+  RecordingMutationAnalysis analysis;
+  analysis.type = RecordingMutationType::Trash;
+  analysis.recordingFile = recordingFile;
+  analysis.revision.recordingFile = recordingFile;
+
+  const RecordingLookupResult recording = recordingLookup.find(recordingFile);
+
+  if (!recording.found) {
+    analysis.constraints.push_back(RecordingConstraint::RecordingMissing);
+    return analysis;
+  }
+
+  analysis.recordingFile = recording.recordingFile;
+  analysis.revision.recordingFile = recording.recordingFile;
+
+  if (replayLookup.isReplaying(recording.recordingFile))
+    analysis.constraints.push_back(RecordingConstraint::ReplayActive);
+
+  analysis.constraints.push_back(RecordingConstraint::UnknownRecordingHandlerState);
+  analysis.constraints.push_back(RecordingConstraint::UnknownTimerState);
+  analysis.constraints.push_back(RecordingConstraint::UnknownSearchTimerState);
+
+  return analysis;
+}

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -204,7 +204,11 @@ RecordingRemoteTimerLookupResult VdrRecordingRemoteTimerLookup::findActive(
   }
 
   LOCK_TIMERS_READ;
-  const cTimer* timer = Timers->GetById(result.timerId, result.remote.c_str());
+
+  const cTimer* timer = Timers->GetById(result.timerId, nullptr);
+  if (!timer)
+    timer = Timers->GetById(result.timerId, result.remote.c_str());
+
   if (!timer)
     return result;
 
@@ -246,7 +250,10 @@ RecordingSearchTimerLookupResult VdrRecordingSearchTimerLookup::findOrigin(
       return result;
     }
 
-    timer = Timers->GetById(id, remote.c_str());
+    timer = Timers->GetById(id, nullptr);
+    if (!timer)
+      timer = Timers->GetById(id, remote.c_str());
+
     if (!timer)
       return result;
   }

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -205,15 +205,23 @@ RecordingRemoteTimerLookupResult VdrRecordingRemoteTimerLookup::findActive(
 
   LOCK_TIMERS_READ;
 
-  const cTimer* timer = Timers->GetById(result.timerId, nullptr);
-  if (!timer)
-    timer = Timers->GetById(result.timerId, result.remote.c_str());
+  const cTimer* localTimer = Timers->GetById(result.timerId, nullptr);
+  if (localTimer) {
+    result.known = true;
+    result.active = false;
+    result.remote.clear();
+    return result;
+  }
 
-  if (!timer)
+  const cTimer* remoteTimer =
+    Timers->GetById(result.timerId, result.remote.c_str());
+
+  if (!remoteTimer)
     return result;
 
   result.known = true;
-  result.active = timer->HasFlags(tfActive) || timer->Recording();
+  result.active =
+    remoteTimer->HasFlags(tfActive) || remoteTimer->Recording();
   return result;
 }
 

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -64,7 +64,7 @@ bool parseRemoteTimerId(
   if (separator == std::string::npos || separator == 0 || separator + 1 >= value.size())
     return false;
 
-  if (!parsePositiveInteger(value.substr(0, separator), timerId) || timerId <= 0)
+  if (!parsePositiveInteger(value.substr(0, separator), timerId))
     return false;
 
   remote = value.substr(separator + 1);
@@ -198,6 +198,11 @@ RecordingRemoteTimerLookupResult VdrRecordingRemoteTimerLookup::findActive(
   if (!parseRemoteTimerId(timerId, result.timerId, result.remote))
     return result;
 
+  if (result.timerId == 0) {
+    result.known = true;
+    return result;
+  }
+
   LOCK_TIMERS_READ;
   const cTimer* timer = Timers->GetById(result.timerId, result.remote.c_str());
   if (!timer)
@@ -235,6 +240,11 @@ RecordingSearchTimerLookupResult VdrRecordingSearchTimerLookup::findOrigin(
     std::string remote;
     if (!parseRemoteTimerId(timerId, id, remote))
       return result;
+
+    if (id == 0) {
+      result.known = true;
+      return result;
+    }
 
     timer = Timers->GetById(id, remote.c_str());
     if (!timer)

--- a/recordinganalysis.cpp
+++ b/recordinganalysis.cpp
@@ -1,6 +1,7 @@
 #include "recordinganalysis.h"
 
 #include <cstring>
+#include <limits>
 
 #include <vdr/menu.h>
 #include <vdr/recording.h>
@@ -58,15 +59,63 @@ RecordingLocalTimerLookupResult VdrRecordingLocalTimerLookup::findActive(
   return result;
 }
 
+RecordingRemoteTimerLookupResult VdrRecordingRemoteTimerLookup::findActive(
+  const std::string& recordingFile) const
+{
+  RecordingRemoteTimerLookupResult result;
+
+  if (recordingFile.empty())
+    return result;
+
+  const cString timerIdText = GetRecordingTimerId(recordingFile.c_str());
+  const char* timerId = *timerIdText;
+
+  if (!timerId || !*timerId) {
+    result.known = true;
+    return result;
+  }
+
+  const std::string value(timerId);
+  const std::string::size_type separator = value.find('@');
+  if (separator == std::string::npos || separator == 0 || separator + 1 >= value.size())
+    return result;
+
+  try {
+    std::size_t parsed = 0;
+    const long id = std::stol(value.substr(0, separator), &parsed, 10);
+    if (parsed != separator || id <= 0 || id > std::numeric_limits<int>::max())
+      return result;
+    result.timerId = static_cast<int>(id);
+  }
+  catch (...) {
+    return result;
+  }
+
+  result.remote = value.substr(separator + 1);
+  if (result.remote.empty())
+    return result;
+
+  LOCK_TIMERS_READ;
+  const cTimer* timer = Timers->GetById(result.timerId, result.remote.c_str());
+  if (!timer)
+    return result;
+
+  result.known = true;
+  result.active = timer->HasFlags(tfActive) || timer->Recording();
+  return result;
+}
+
 RecordingTrashAnalyzer::RecordingTrashAnalyzer(
   const IRecordingLookup& recordingLookup,
   const IRecordingReplayLookup& replayLookup,
   const IRecordingHandlerLookup& recordingHandlerLookup,
-  const IRecordingLocalTimerLookup& localTimerLookup)
+  const IRecordingLocalTimerLookup& localTimerLookup,
+  const IRecordingRemoteTimerLookup& remoteTimerLookup)
   : recordingLookup(recordingLookup),
     replayLookup(replayLookup),
     recordingHandlerLookup(recordingHandlerLookup),
-    localTimerLookup(localTimerLookup)
+    localTimerLookup(localTimerLookup),
+    remoteTimerLookup(remoteTimerLookup)
 {
 }
 
@@ -107,7 +156,14 @@ RecordingMutationAnalysis RecordingTrashAnalyzer::analyze(
   else if (localTimer.active)
     analysis.constraints.push_back(RecordingConstraint::LocalTimerActive);
 
-  analysis.constraints.push_back(RecordingConstraint::UnknownRemoteTimerState);
+  const RecordingRemoteTimerLookupResult remoteTimer =
+    remoteTimerLookup.findActive(recording.recordingFile);
+
+  if (!remoteTimer.known)
+    analysis.constraints.push_back(RecordingConstraint::UnknownRemoteTimerState);
+  else if (remoteTimer.active)
+    analysis.constraints.push_back(RecordingConstraint::RemoteTimerActive);
+
   analysis.constraints.push_back(RecordingConstraint::UnknownSearchTimerState);
 
   return analysis;

--- a/recordinganalysis.h
+++ b/recordinganalysis.h
@@ -17,6 +17,12 @@ struct RecordingHandlerLookupResult
   bool busy = false;
 };
 
+struct RecordingLocalTimerLookupResult
+{
+  bool known = false;
+  bool active = false;
+};
+
 class IRecordingLookup
 {
 public:
@@ -38,6 +44,13 @@ public:
   virtual RecordingHandlerLookupResult getUsage(const std::string& recordingFile) const = 0;
 };
 
+class IRecordingLocalTimerLookup
+{
+public:
+  virtual ~IRecordingLocalTimerLookup() = default;
+  virtual RecordingLocalTimerLookupResult findActive(const std::string& recordingFile) const = 0;
+};
+
 class VdrRecordingLookup : public IRecordingLookup
 {
 public:
@@ -56,13 +69,20 @@ public:
   RecordingHandlerLookupResult getUsage(const std::string& recordingFile) const override;
 };
 
+class VdrRecordingLocalTimerLookup : public IRecordingLocalTimerLookup
+{
+public:
+  RecordingLocalTimerLookupResult findActive(const std::string& recordingFile) const override;
+};
+
 class RecordingTrashAnalyzer
 {
 public:
   RecordingTrashAnalyzer(
     const IRecordingLookup& recordingLookup,
     const IRecordingReplayLookup& replayLookup,
-    const IRecordingHandlerLookup& recordingHandlerLookup);
+    const IRecordingHandlerLookup& recordingHandlerLookup,
+    const IRecordingLocalTimerLookup& localTimerLookup);
 
   RecordingMutationAnalysis analyze(const std::string& recordingFile) const;
 
@@ -70,6 +90,7 @@ private:
   const IRecordingLookup& recordingLookup;
   const IRecordingReplayLookup& replayLookup;
   const IRecordingHandlerLookup& recordingHandlerLookup;
+  const IRecordingLocalTimerLookup& localTimerLookup;
 };
 
 #endif

--- a/recordinganalysis.h
+++ b/recordinganalysis.h
@@ -31,6 +31,13 @@ struct RecordingRemoteTimerLookupResult
   std::string remote;
 };
 
+struct RecordingSearchTimerLookupResult
+{
+  bool known = false;
+  bool searchTimerRecording = false;
+  int searchTimerId = -1;
+};
+
 class IRecordingLookup
 {
 public:
@@ -66,6 +73,13 @@ public:
   virtual RecordingRemoteTimerLookupResult findActive(const std::string& recordingFile) const = 0;
 };
 
+class IRecordingSearchTimerLookup
+{
+public:
+  virtual ~IRecordingSearchTimerLookup() = default;
+  virtual RecordingSearchTimerLookupResult findOrigin(const std::string& recordingFile) const = 0;
+};
+
 class VdrRecordingLookup : public IRecordingLookup
 {
 public:
@@ -96,6 +110,12 @@ public:
   RecordingRemoteTimerLookupResult findActive(const std::string& recordingFile) const override;
 };
 
+class VdrRecordingSearchTimerLookup : public IRecordingSearchTimerLookup
+{
+public:
+  RecordingSearchTimerLookupResult findOrigin(const std::string& recordingFile) const override;
+};
+
 class RecordingTrashAnalyzer
 {
 public:
@@ -104,7 +124,8 @@ public:
     const IRecordingReplayLookup& replayLookup,
     const IRecordingHandlerLookup& recordingHandlerLookup,
     const IRecordingLocalTimerLookup& localTimerLookup,
-    const IRecordingRemoteTimerLookup& remoteTimerLookup);
+    const IRecordingRemoteTimerLookup& remoteTimerLookup,
+    const IRecordingSearchTimerLookup& searchTimerLookup);
 
   RecordingMutationAnalysis analyze(const std::string& recordingFile) const;
 
@@ -114,6 +135,7 @@ private:
   const IRecordingHandlerLookup& recordingHandlerLookup;
   const IRecordingLocalTimerLookup& localTimerLookup;
   const IRecordingRemoteTimerLookup& remoteTimerLookup;
+  const IRecordingSearchTimerLookup& searchTimerLookup;
 };
 
 #endif

--- a/recordinganalysis.h
+++ b/recordinganalysis.h
@@ -23,6 +23,14 @@ struct RecordingLocalTimerLookupResult
   bool active = false;
 };
 
+struct RecordingRemoteTimerLookupResult
+{
+  bool known = false;
+  bool active = false;
+  int timerId = 0;
+  std::string remote;
+};
+
 class IRecordingLookup
 {
 public:
@@ -51,6 +59,13 @@ public:
   virtual RecordingLocalTimerLookupResult findActive(const std::string& recordingFile) const = 0;
 };
 
+class IRecordingRemoteTimerLookup
+{
+public:
+  virtual ~IRecordingRemoteTimerLookup() = default;
+  virtual RecordingRemoteTimerLookupResult findActive(const std::string& recordingFile) const = 0;
+};
+
 class VdrRecordingLookup : public IRecordingLookup
 {
 public:
@@ -75,6 +90,12 @@ public:
   RecordingLocalTimerLookupResult findActive(const std::string& recordingFile) const override;
 };
 
+class VdrRecordingRemoteTimerLookup : public IRecordingRemoteTimerLookup
+{
+public:
+  RecordingRemoteTimerLookupResult findActive(const std::string& recordingFile) const override;
+};
+
 class RecordingTrashAnalyzer
 {
 public:
@@ -82,7 +103,8 @@ public:
     const IRecordingLookup& recordingLookup,
     const IRecordingReplayLookup& replayLookup,
     const IRecordingHandlerLookup& recordingHandlerLookup,
-    const IRecordingLocalTimerLookup& localTimerLookup);
+    const IRecordingLocalTimerLookup& localTimerLookup,
+    const IRecordingRemoteTimerLookup& remoteTimerLookup);
 
   RecordingMutationAnalysis analyze(const std::string& recordingFile) const;
 
@@ -91,6 +113,7 @@ private:
   const IRecordingReplayLookup& replayLookup;
   const IRecordingHandlerLookup& recordingHandlerLookup;
   const IRecordingLocalTimerLookup& localTimerLookup;
+  const IRecordingRemoteTimerLookup& remoteTimerLookup;
 };
 
 #endif

--- a/recordinganalysis.h
+++ b/recordinganalysis.h
@@ -138,4 +138,28 @@ private:
   const IRecordingSearchTimerLookup& searchTimerLookup;
 };
 
+class RecordingMoveAnalyzer
+{
+public:
+  RecordingMoveAnalyzer(
+    const IRecordingLookup& recordingLookup,
+    const IRecordingReplayLookup& replayLookup,
+    const IRecordingHandlerLookup& recordingHandlerLookup,
+    const IRecordingLocalTimerLookup& localTimerLookup,
+    const IRecordingRemoteTimerLookup& remoteTimerLookup,
+    const IRecordingSearchTimerLookup& searchTimerLookup);
+
+  RecordingMutationAnalysis analyze(
+    const std::string& recordingFile,
+    const std::string& targetFile) const;
+
+private:
+  const IRecordingLookup& recordingLookup;
+  const IRecordingReplayLookup& replayLookup;
+  const IRecordingHandlerLookup& recordingHandlerLookup;
+  const IRecordingLocalTimerLookup& localTimerLookup;
+  const IRecordingRemoteTimerLookup& remoteTimerLookup;
+  const IRecordingSearchTimerLookup& searchTimerLookup;
+};
+
 #endif

--- a/recordinganalysis.h
+++ b/recordinganalysis.h
@@ -1,0 +1,54 @@
+#ifndef __RECORDINGANALYSIS_H
+#define __RECORDINGANALYSIS_H
+
+#include "recordingmutation.h"
+
+#include <string>
+
+struct RecordingLookupResult
+{
+  bool found = false;
+  std::string recordingFile;
+};
+
+class IRecordingLookup
+{
+public:
+  virtual ~IRecordingLookup() = default;
+  virtual RecordingLookupResult find(const std::string& recordingFile) const = 0;
+};
+
+class IRecordingReplayLookup
+{
+public:
+  virtual ~IRecordingReplayLookup() = default;
+  virtual bool isReplaying(const std::string& recordingFile) const = 0;
+};
+
+class VdrRecordingLookup : public IRecordingLookup
+{
+public:
+  RecordingLookupResult find(const std::string& recordingFile) const override;
+};
+
+class VdrRecordingReplayLookup : public IRecordingReplayLookup
+{
+public:
+  bool isReplaying(const std::string& recordingFile) const override;
+};
+
+class RecordingTrashAnalyzer
+{
+public:
+  RecordingTrashAnalyzer(
+    const IRecordingLookup& recordingLookup,
+    const IRecordingReplayLookup& replayLookup);
+
+  RecordingMutationAnalysis analyze(const std::string& recordingFile) const;
+
+private:
+  const IRecordingLookup& recordingLookup;
+  const IRecordingReplayLookup& replayLookup;
+};
+
+#endif

--- a/recordinganalysis.h
+++ b/recordinganalysis.h
@@ -11,6 +11,12 @@ struct RecordingLookupResult
   std::string recordingFile;
 };
 
+struct RecordingHandlerLookupResult
+{
+  bool known = false;
+  bool busy = false;
+};
+
 class IRecordingLookup
 {
 public:
@@ -25,6 +31,13 @@ public:
   virtual bool isReplaying(const std::string& recordingFile) const = 0;
 };
 
+class IRecordingHandlerLookup
+{
+public:
+  virtual ~IRecordingHandlerLookup() = default;
+  virtual RecordingHandlerLookupResult getUsage(const std::string& recordingFile) const = 0;
+};
+
 class VdrRecordingLookup : public IRecordingLookup
 {
 public:
@@ -37,18 +50,26 @@ public:
   bool isReplaying(const std::string& recordingFile) const override;
 };
 
+class VdrRecordingHandlerLookup : public IRecordingHandlerLookup
+{
+public:
+  RecordingHandlerLookupResult getUsage(const std::string& recordingFile) const override;
+};
+
 class RecordingTrashAnalyzer
 {
 public:
   RecordingTrashAnalyzer(
     const IRecordingLookup& recordingLookup,
-    const IRecordingReplayLookup& replayLookup);
+    const IRecordingReplayLookup& replayLookup,
+    const IRecordingHandlerLookup& recordingHandlerLookup);
 
   RecordingMutationAnalysis analyze(const std::string& recordingFile) const;
 
 private:
   const IRecordingLookup& recordingLookup;
   const IRecordingReplayLookup& replayLookup;
+  const IRecordingHandlerLookup& recordingHandlerLookup;
 };
 
 #endif

--- a/recordingexecution.cpp
+++ b/recordingexecution.cpp
@@ -1,0 +1,67 @@
+#include "recordingexecution.h"
+
+namespace {
+
+bool sameRevision(
+  const RecordingMutationRevision& left,
+  const RecordingMutationRevision& right)
+{
+  return left.recordingFile == right.recordingFile
+    && left.recordingsState == right.recordingsState
+    && left.timersState == right.timersState;
+}
+
+}
+
+RecordingTrashExecutionGate::RecordingTrashExecutionGate(
+  const RecordingTrashAnalyzer& analyzer,
+  const RecordingMutationPlanner& planner)
+  : analyzer(analyzer),
+    planner(planner)
+{
+}
+
+RecordingTrashExecutionGateResult RecordingTrashExecutionGate::validate(
+  const std::string& recordingFile,
+  const RecordingMutationRevision& expectedRevision,
+  const RecordingMutationPolicy& policy) const
+{
+  RecordingTrashExecutionGateResult result;
+  result.recordingFile = recordingFile;
+  result.expectedRevision = expectedRevision;
+
+  const RecordingMutationAnalysis analysis = analyzer.analyze(recordingFile);
+  const RecordingMutationPlan plan = planner.buildTrashPlan(analysis, policy);
+
+  result.currentRevision = analysis.revision;
+  result.blockers = plan.blockers;
+  result.warnings = plan.warnings;
+
+  if (!sameRevision(expectedRevision, analysis.revision)) {
+    result.status = RecordingTrashExecutionGateStatus::Conflict;
+    return result;
+  }
+
+  if (!plan.executable) {
+    result.status = RecordingTrashExecutionGateStatus::Blocked;
+    return result;
+  }
+
+  result.status = RecordingTrashExecutionGateStatus::Ready;
+  return result;
+}
+
+const char* RecordingTrashExecutionGateStatusName(
+  RecordingTrashExecutionGateStatus status)
+{
+  switch (status) {
+    case RecordingTrashExecutionGateStatus::Ready:
+      return "ready";
+    case RecordingTrashExecutionGateStatus::Conflict:
+      return "conflict";
+    case RecordingTrashExecutionGateStatus::Blocked:
+      return "blocked";
+  }
+
+  return "blocked";
+}

--- a/recordingexecution.h
+++ b/recordingexecution.h
@@ -41,35 +41,6 @@ private:
   const RecordingMutationPlanner& planner;
 };
 
-struct RecordingMoveExecutionGateResult
-{
-  RecordingTrashExecutionGateStatus status = RecordingTrashExecutionGateStatus::Blocked;
-  std::string recordingFile;
-  std::string targetFile;
-  RecordingMutationRevision expectedRevision;
-  RecordingMutationRevision currentRevision;
-  std::vector<RecordingConstraint> blockers;
-  std::vector<std::string> warnings;
-};
-
-class RecordingMoveExecutionGate
-{
-public:
-  RecordingMoveExecutionGate(
-    const RecordingMoveAnalyzer& analyzer,
-    const RecordingMutationPlanner& planner);
-
-  RecordingMoveExecutionGateResult validate(
-    const std::string& recordingFile,
-    const std::string& targetFile,
-    const RecordingMutationRevision& expectedRevision,
-    const RecordingMutationPolicy& policy) const;
-
-private:
-  const RecordingMoveAnalyzer& analyzer;
-  const RecordingMutationPlanner& planner;
-};
-
 const char* RecordingTrashExecutionGateStatusName(
   RecordingTrashExecutionGateStatus status);
 

--- a/recordingexecution.h
+++ b/recordingexecution.h
@@ -1,0 +1,47 @@
+#ifndef __RECORDINGEXECUTION_H
+#define __RECORDINGEXECUTION_H
+
+#include "recordinganalysis.h"
+#include "recordingmutation.h"
+
+#include <string>
+#include <vector>
+
+enum class RecordingTrashExecutionGateStatus
+{
+  Ready,
+  Conflict,
+  Blocked
+};
+
+struct RecordingTrashExecutionGateResult
+{
+  RecordingTrashExecutionGateStatus status = RecordingTrashExecutionGateStatus::Blocked;
+  std::string recordingFile;
+  RecordingMutationRevision expectedRevision;
+  RecordingMutationRevision currentRevision;
+  std::vector<RecordingConstraint> blockers;
+  std::vector<std::string> warnings;
+};
+
+class RecordingTrashExecutionGate
+{
+public:
+  RecordingTrashExecutionGate(
+    const RecordingTrashAnalyzer& analyzer,
+    const RecordingMutationPlanner& planner);
+
+  RecordingTrashExecutionGateResult validate(
+    const std::string& recordingFile,
+    const RecordingMutationRevision& expectedRevision,
+    const RecordingMutationPolicy& policy) const;
+
+private:
+  const RecordingTrashAnalyzer& analyzer;
+  const RecordingMutationPlanner& planner;
+};
+
+const char* RecordingTrashExecutionGateStatusName(
+  RecordingTrashExecutionGateStatus status);
+
+#endif

--- a/recordingexecution.h
+++ b/recordingexecution.h
@@ -41,6 +41,35 @@ private:
   const RecordingMutationPlanner& planner;
 };
 
+struct RecordingMoveExecutionGateResult
+{
+  RecordingTrashExecutionGateStatus status = RecordingTrashExecutionGateStatus::Blocked;
+  std::string recordingFile;
+  std::string targetFile;
+  RecordingMutationRevision expectedRevision;
+  RecordingMutationRevision currentRevision;
+  std::vector<RecordingConstraint> blockers;
+  std::vector<std::string> warnings;
+};
+
+class RecordingMoveExecutionGate
+{
+public:
+  RecordingMoveExecutionGate(
+    const RecordingMoveAnalyzer& analyzer,
+    const RecordingMutationPlanner& planner);
+
+  RecordingMoveExecutionGateResult validate(
+    const std::string& recordingFile,
+    const std::string& targetFile,
+    const RecordingMutationRevision& expectedRevision,
+    const RecordingMutationPolicy& policy) const;
+
+private:
+  const RecordingMoveAnalyzer& analyzer;
+  const RecordingMutationPlanner& planner;
+};
+
 const char* RecordingTrashExecutionGateStatusName(
   RecordingTrashExecutionGateStatus status);
 

--- a/recordingmove.cpp
+++ b/recordingmove.cpp
@@ -1,0 +1,142 @@
+#include "recordingmove.h"
+
+#include "recordinganalysis.h"
+#include "recordingmoveexecution.h"
+#include "recordingmoveexecutor.h"
+#include "recordingmutation.h"
+#include "tools.h"
+
+#include <cxxtools/jsonserializer.h>
+
+#include <string>
+
+namespace {
+
+bool parseLongLong(const std::string& value, long long& result)
+{
+  if (value.empty())
+    return false;
+
+  try {
+    std::size_t parsed = 0;
+    result = std::stoll(value, &parsed, 10);
+    return parsed == value.size();
+  }
+  catch (...) {
+    return false;
+  }
+}
+
+}
+
+void RecordingMoveResponder::reply(
+  std::ostream& out,
+  cxxtools::http::Request& request,
+  cxxtools::http::Reply& reply)
+{
+  QueryHandler::addHeader(reply);
+
+  if (request.method() == "OPTIONS") {
+    reply.addHeader("Allow", "POST");
+    reply.httpReturn(200, "OK");
+    return;
+  }
+
+  if (request.method() != "POST") {
+    reply.httpReturn(501, "Only POST method is supported by the /recordings/move service.");
+    return;
+  }
+
+  QueryHandler query("/recordings/move", request);
+  const std::string recordingFile = query.getBodyAsString("file");
+  const std::string targetFile = query.getBodyAsString("target_file");
+  const std::string recordingsStateText =
+    query.getBodyAsString("revision_recordings_state");
+  const std::string timersStateText =
+    query.getBodyAsString("revision_timers_state");
+
+  long long recordingsState = 0;
+  long long timersState = 0;
+
+  if (recordingFile.empty()) {
+    reply.httpReturn(400, "Recording file is missing.");
+    return;
+  }
+
+  if (targetFile.empty()) {
+    reply.httpReturn(400, "Recording move target file is missing.");
+    return;
+  }
+
+  if (!parseLongLong(recordingsStateText, recordingsState) ||
+      !parseLongLong(timersStateText, timersState)) {
+    reply.httpReturn(400, "Recording move revision is missing or invalid.");
+    return;
+  }
+
+  RecordingMutationPolicy policy;
+  policy.allowRecordingHandlerStop = false;
+  policy.allowReplayStop = false;
+  policy.allowLocalTimerStop = false;
+  policy.allowRemoteTimerStop = false;
+
+  VdrRecordingLookup recordingLookup;
+  VdrRecordingReplayLookup replayLookup;
+  VdrRecordingHandlerLookup recordingHandlerLookup;
+  VdrRecordingLocalTimerLookup localTimerLookup;
+  VdrRecordingRemoteTimerLookup remoteTimerLookup;
+  VdrRecordingSearchTimerLookup searchTimerLookup;
+
+  RecordingMoveAnalyzer analyzer(
+    recordingLookup,
+    replayLookup,
+    recordingHandlerLookup,
+    localTimerLookup,
+    remoteTimerLookup,
+    searchTimerLookup);
+
+  RecordingMutationPlanner planner;
+  RecordingMoveExecutionGate gate(analyzer, planner);
+  RecordingMoveExecutor executor(gate);
+
+  RecordingMutationRevision expectedRevision;
+  expectedRevision.recordingFile = recordingFile;
+  expectedRevision.targetFile = targetFile;
+  expectedRevision.recordingsState = recordingsState;
+  expectedRevision.timersState = timersState;
+
+  const RecordingMoveExecutorResult result = executor.executeNormalCase(
+    recordingFile,
+    targetFile,
+    expectedRevision,
+    policy);
+
+  switch (result.status) {
+    case RecordingMoveExecutorStatus::Conflict:
+      reply.httpReturn(409, result.message);
+      return;
+    case RecordingMoveExecutorStatus::Blocked:
+      reply.httpReturn(423, result.message);
+      return;
+    case RecordingMoveExecutorStatus::NotFound:
+      reply.httpReturn(404, result.message);
+      return;
+    case RecordingMoveExecutorStatus::Failed:
+      reply.httpReturn(500, result.message);
+      return;
+    case RecordingMoveExecutorStatus::Moved:
+    case RecordingMoveExecutorStatus::AlreadyMoved:
+      break;
+  }
+
+  reply.addHeader("Content-Type", "application/json; charset=utf-8");
+
+  cxxtools::JsonSerializer serializer(out);
+  serializer.serialize(
+    std::string(RecordingMoveExecutorStatusName(result.status)),
+    "status");
+  serializer.serialize(result.recordingFile, "recording_file");
+  serializer.serialize(result.targetFile, "target_file");
+  serializer.serialize(result.message, "message");
+  serializer.finish();
+}

--- a/recordingmove.h
+++ b/recordingmove.h
@@ -1,0 +1,25 @@
+#ifndef __RECORDINGMOVE_H
+#define __RECORDINGMOVE_H
+
+#include <cxxtools/http/request.h>
+#include <cxxtools/http/reply.h>
+#include <cxxtools/http/responder.h>
+
+class RecordingMoveResponder : public cxxtools::http::Responder
+{
+public:
+  explicit RecordingMoveResponder(cxxtools::http::Service& service)
+    : cxxtools::http::Responder(service)
+  {
+  }
+
+  void reply(
+    std::ostream& out,
+    cxxtools::http::Request& request,
+    cxxtools::http::Reply& reply) override;
+};
+
+typedef cxxtools::http::CachedService<RecordingMoveResponder>
+  RecordingMoveService;
+
+#endif

--- a/recordingmoveanalysis.cpp
+++ b/recordingmoveanalysis.cpp
@@ -1,0 +1,188 @@
+#include "recordinganalysis.h"
+
+#include <cstdint>
+#include <sstream>
+#include <sys/stat.h>
+
+namespace {
+
+long long fingerprint(const std::string& value)
+{
+  std::uint64_t hash = 1469598103934665603ULL;
+  for (unsigned char character : value) {
+    hash ^= character;
+    hash *= 1099511628211ULL;
+  }
+  return static_cast<long long>(hash & 0x7FFFFFFFFFFFFFFFULL);
+}
+
+void appendFileState(
+  std::ostringstream& state,
+  const std::string& recordingFile,
+  bool found)
+{
+  state << recordingFile << '|';
+  state << (found ? "found" : "missing");
+
+  struct stat fileState;
+  if (found && stat(recordingFile.c_str(), &fileState) == 0) {
+    state << '|' << static_cast<unsigned long long>(fileState.st_dev);
+    state << '|' << static_cast<unsigned long long>(fileState.st_ino);
+    state << '|' << static_cast<long long>(fileState.st_mtime);
+    state << '|' << static_cast<long long>(fileState.st_ctime);
+  }
+  else if (found) {
+    state << "|stat-unavailable";
+  }
+}
+
+long long moveRecordingFingerprint(
+  const std::string& recordingFile,
+  bool recordingFound,
+  const std::string& targetFile,
+  bool targetFound)
+{
+  std::ostringstream state;
+  state << "source=";
+  appendFileState(state, recordingFile, recordingFound);
+  state << "|target=";
+  appendFileState(state, targetFile, targetFound);
+  return fingerprint(state.str());
+}
+
+long long timerFingerprint(
+  bool replaying,
+  const RecordingHandlerLookupResult& handlerUsage,
+  const RecordingLocalTimerLookupResult& localTimer,
+  const RecordingRemoteTimerLookupResult& remoteTimer,
+  const RecordingSearchTimerLookupResult& searchTimer)
+{
+  std::ostringstream state;
+  state << "replay=" << replaying;
+  state << "|handler-known=" << handlerUsage.known;
+  state << "|handler-busy=" << handlerUsage.busy;
+  state << "|local-known=" << localTimer.known;
+  state << "|local-active=" << localTimer.active;
+  state << "|remote-known=" << remoteTimer.known;
+  state << "|remote-active=" << remoteTimer.active;
+  state << "|remote-id=" << remoteTimer.timerId;
+  state << "|remote=" << remoteTimer.remote;
+  state << "|search-known=" << searchTimer.known;
+  state << "|search-recording=" << searchTimer.searchTimerRecording;
+  state << "|search-id=" << searchTimer.searchTimerId;
+  return fingerprint(state.str());
+}
+
+bool isAbsoluteRecordingTarget(const std::string& targetFile)
+{
+  return targetFile.size() > 1 &&
+    targetFile.front() == '/' &&
+    targetFile.back() != '/';
+}
+
+}
+
+RecordingMoveAnalyzer::RecordingMoveAnalyzer(
+  const IRecordingLookup& recordingLookup,
+  const IRecordingReplayLookup& replayLookup,
+  const IRecordingHandlerLookup& recordingHandlerLookup,
+  const IRecordingLocalTimerLookup& localTimerLookup,
+  const IRecordingRemoteTimerLookup& remoteTimerLookup,
+  const IRecordingSearchTimerLookup& searchTimerLookup)
+  : recordingLookup(recordingLookup),
+    replayLookup(replayLookup),
+    recordingHandlerLookup(recordingHandlerLookup),
+    localTimerLookup(localTimerLookup),
+    remoteTimerLookup(remoteTimerLookup),
+    searchTimerLookup(searchTimerLookup)
+{
+}
+
+RecordingMutationAnalysis RecordingMoveAnalyzer::analyze(
+  const std::string& recordingFile,
+  const std::string& targetFile) const
+{
+  RecordingMutationAnalysis analysis;
+  analysis.type = RecordingMutationType::Move;
+  analysis.recordingFile = recordingFile;
+  analysis.targetFile = targetFile;
+  analysis.revision.recordingFile = recordingFile;
+  analysis.revision.targetFile = targetFile;
+
+  const RecordingLookupResult recording = recordingLookup.find(recordingFile);
+  const RecordingLookupResult target = targetFile.empty()
+    ? RecordingLookupResult()
+    : recordingLookup.find(targetFile);
+
+  analysis.revision.recordingsState = moveRecordingFingerprint(
+    recordingFile,
+    recording.found,
+    targetFile,
+    target.found);
+
+  if (!recording.found)
+    analysis.constraints.push_back(RecordingConstraint::RecordingMissing);
+
+  if (targetFile.empty())
+    analysis.constraints.push_back(RecordingConstraint::MoveTargetMissing);
+  else if (!isAbsoluteRecordingTarget(targetFile))
+    analysis.constraints.push_back(RecordingConstraint::MoveTargetInvalid);
+
+  if (!recordingFile.empty() && recordingFile == targetFile)
+    analysis.constraints.push_back(RecordingConstraint::MoveTargetSameAsSource);
+
+  if (target.found && target.recordingFile != recording.recordingFile)
+    analysis.constraints.push_back(RecordingConstraint::MoveTargetExists);
+
+  if (!recording.found)
+    return analysis;
+
+  analysis.recordingFile = recording.recordingFile;
+  analysis.revision.recordingFile = recording.recordingFile;
+
+  const bool replaying = replayLookup.isReplaying(recording.recordingFile);
+  if (replaying)
+    analysis.constraints.push_back(RecordingConstraint::ReplayActive);
+
+  const RecordingHandlerLookupResult handlerUsage =
+    recordingHandlerLookup.getUsage(recording.recordingFile);
+  if (!handlerUsage.known)
+    analysis.constraints.push_back(RecordingConstraint::UnknownRecordingHandlerState);
+  else if (handlerUsage.busy)
+    analysis.constraints.push_back(RecordingConstraint::RecordingHandlerBusy);
+
+  const RecordingLocalTimerLookupResult localTimer =
+    localTimerLookup.findActive(recording.recordingFile);
+  if (!localTimer.known)
+    analysis.constraints.push_back(RecordingConstraint::UnknownLocalTimerState);
+  else if (localTimer.active)
+    analysis.constraints.push_back(RecordingConstraint::LocalTimerActive);
+
+  const RecordingRemoteTimerLookupResult remoteTimer =
+    remoteTimerLookup.findActive(recording.recordingFile);
+  if (!remoteTimer.known)
+    analysis.constraints.push_back(RecordingConstraint::UnknownRemoteTimerState);
+  else if (remoteTimer.active)
+    analysis.constraints.push_back(RecordingConstraint::RemoteTimerActive);
+
+  const RecordingSearchTimerLookupResult searchTimer =
+    searchTimerLookup.findOrigin(recording.recordingFile);
+  if (!searchTimer.known)
+    analysis.constraints.push_back(RecordingConstraint::UnknownSearchTimerState);
+  else if (searchTimer.searchTimerRecording)
+    analysis.constraints.push_back(RecordingConstraint::SearchTimerRecording);
+
+  analysis.revision.recordingsState = moveRecordingFingerprint(
+    recording.recordingFile,
+    true,
+    targetFile,
+    target.found);
+  analysis.revision.timersState = timerFingerprint(
+    replaying,
+    handlerUsage,
+    localTimer,
+    remoteTimer,
+    searchTimer);
+
+  return analysis;
+}

--- a/recordingmoveexecution.cpp
+++ b/recordingmoveexecution.cpp
@@ -1,0 +1,70 @@
+#include "recordingmoveexecution.h"
+
+namespace {
+
+bool sameRevision(
+  const RecordingMutationRevision& left,
+  const RecordingMutationRevision& right)
+{
+  return left.recordingFile == right.recordingFile
+    && left.targetFile == right.targetFile
+    && left.recordingsState == right.recordingsState
+    && left.timersState == right.timersState;
+}
+
+}
+
+RecordingMoveExecutionGate::RecordingMoveExecutionGate(
+  const RecordingMoveAnalyzer& analyzer,
+  const RecordingMutationPlanner& planner)
+  : analyzer(analyzer),
+    planner(planner)
+{
+}
+
+RecordingMoveExecutionGateResult RecordingMoveExecutionGate::validate(
+  const std::string& recordingFile,
+  const std::string& targetFile,
+  const RecordingMutationRevision& expectedRevision,
+  const RecordingMutationPolicy& policy) const
+{
+  RecordingMoveExecutionGateResult result;
+  result.recordingFile = recordingFile;
+  result.targetFile = targetFile;
+  result.expectedRevision = expectedRevision;
+
+  const RecordingMutationAnalysis analysis = analyzer.analyze(recordingFile, targetFile);
+  const RecordingMutationPlan plan = planner.buildMovePlan(analysis, policy);
+
+  result.currentRevision = analysis.revision;
+  result.blockers = plan.blockers;
+  result.warnings = plan.warnings;
+
+  if (!sameRevision(expectedRevision, analysis.revision)) {
+    result.status = RecordingMoveExecutionGateStatus::Conflict;
+    return result;
+  }
+
+  if (!plan.executable) {
+    result.status = RecordingMoveExecutionGateStatus::Blocked;
+    return result;
+  }
+
+  result.status = RecordingMoveExecutionGateStatus::Ready;
+  return result;
+}
+
+const char* RecordingMoveExecutionGateStatusName(
+  RecordingMoveExecutionGateStatus status)
+{
+  switch (status) {
+    case RecordingMoveExecutionGateStatus::Ready:
+      return "ready";
+    case RecordingMoveExecutionGateStatus::Conflict:
+      return "conflict";
+    case RecordingMoveExecutionGateStatus::Blocked:
+      return "blocked";
+  }
+
+  return "blocked";
+}

--- a/recordingmoveexecution.h
+++ b/recordingmoveexecution.h
@@ -1,0 +1,49 @@
+#ifndef __RECORDINGMOVEEXECUTION_H
+#define __RECORDINGMOVEEXECUTION_H
+
+#include "recordinganalysis.h"
+#include "recordingmutation.h"
+
+#include <string>
+#include <vector>
+
+enum class RecordingMoveExecutionGateStatus
+{
+  Ready,
+  Conflict,
+  Blocked
+};
+
+struct RecordingMoveExecutionGateResult
+{
+  RecordingMoveExecutionGateStatus status = RecordingMoveExecutionGateStatus::Blocked;
+  std::string recordingFile;
+  std::string targetFile;
+  RecordingMutationRevision expectedRevision;
+  RecordingMutationRevision currentRevision;
+  std::vector<RecordingConstraint> blockers;
+  std::vector<std::string> warnings;
+};
+
+class RecordingMoveExecutionGate
+{
+public:
+  RecordingMoveExecutionGate(
+    const RecordingMoveAnalyzer& analyzer,
+    const RecordingMutationPlanner& planner);
+
+  RecordingMoveExecutionGateResult validate(
+    const std::string& recordingFile,
+    const std::string& targetFile,
+    const RecordingMutationRevision& expectedRevision,
+    const RecordingMutationPolicy& policy) const;
+
+private:
+  const RecordingMoveAnalyzer& analyzer;
+  const RecordingMutationPlanner& planner;
+};
+
+const char* RecordingMoveExecutionGateStatusName(
+  RecordingMoveExecutionGateStatus status);
+
+#endif

--- a/recordingmoveexecutor.cpp
+++ b/recordingmoveexecutor.cpp
@@ -1,0 +1,159 @@
+#include "recordingmoveexecutor.h"
+
+#include "changestatetracker.h"
+#include "tools.h"
+
+#include <cstring>
+#include <unistd.h>
+
+#include <vdr/menu.h>
+#include <vdr/recording.h>
+#include <vdr/videodir.h>
+
+namespace {
+
+bool pathExists(const std::string& path)
+{
+  return !path.empty() && access(path.c_str(), F_OK) == 0;
+}
+
+}
+
+RecordingMoveExecutor::RecordingMoveExecutor(const RecordingMoveExecutionGate& gate)
+  : gate(gate)
+{
+}
+
+RecordingMoveExecutorResult RecordingMoveExecutor::executeNormalCase(
+  const std::string& recordingFile,
+  const std::string& targetFile,
+  const RecordingMutationRevision& expectedRevision,
+  const RecordingMutationPolicy& policy) const
+{
+  RecordingMoveExecutorResult result;
+  result.recordingFile = recordingFile;
+  result.targetFile = targetFile;
+
+  if (!pathExists(recordingFile) && pathExists(targetFile)) {
+    result.status = RecordingMoveExecutorStatus::AlreadyMoved;
+    result.message = "Recording is already present at the requested target.";
+    return result;
+  }
+
+  result.gate = gate.validate(recordingFile, targetFile, expectedRevision, policy);
+
+  if (result.gate.status == RecordingMoveExecutionGateStatus::Conflict) {
+    result.status = RecordingMoveExecutorStatus::Conflict;
+    result.message = "Recording state changed after preview.";
+    return result;
+  }
+
+  if (result.gate.status != RecordingMoveExecutionGateStatus::Ready) {
+    result.status = RecordingMoveExecutorStatus::Blocked;
+    result.message = "Recording move execution is blocked by the current state or policy.";
+    return result;
+  }
+
+  LOCK_TIMERS_WRITE;
+  LOCK_RECORDINGS_WRITE;
+
+  cRecording* recording = Recordings->GetByName(recordingFile.c_str());
+  if (!recording) {
+    if (!pathExists(recordingFile) && pathExists(targetFile)) {
+      result.status = RecordingMoveExecutorStatus::AlreadyMoved;
+      result.message = "Recording is already present at the requested target.";
+    }
+    else {
+      result.status = RecordingMoveExecutorStatus::NotFound;
+      result.message = "Recording disappeared before execution.";
+    }
+    return result;
+  }
+
+  if (pathExists(targetFile) || Recordings->GetByName(targetFile.c_str())) {
+    result.status = RecordingMoveExecutorStatus::Conflict;
+    result.message = "The recording move target already exists.";
+    return result;
+  }
+
+  const char* nowReplaying = cReplayControl::NowReplaying();
+  if (nowReplaying && std::strcmp(nowReplaying, recordingFile.c_str()) == 0) {
+    result.status = RecordingMoveExecutorStatus::Conflict;
+    result.message = "Recording started replaying after validation.";
+    return result;
+  }
+
+  if (RecordingsHandler.GetUsage(recordingFile.c_str()) != ruNone) {
+    result.status = RecordingMoveExecutorStatus::Conflict;
+    result.message = "Recording handler usage changed after validation.";
+    return result;
+  }
+
+  if (cRecordControls::GetRecordControl(recordingFile.c_str()) != nullptr) {
+    result.status = RecordingMoveExecutorStatus::Conflict;
+    result.message = "A local recording control became active after validation.";
+    return result;
+  }
+
+  const cString timerIdText = GetRecordingTimerId(recordingFile.c_str());
+  const char* timerId = *timerIdText;
+  if (timerId && *timerId) {
+    result.status = RecordingMoveExecutorStatus::Conflict;
+    result.message = "A timer association appeared after validation.";
+    return result;
+  }
+
+  const std::string oldName = recording->FileName();
+  if (!VdrExtension::MoveDirectory(oldName, targetFile, false)) {
+    result.status = RecordingMoveExecutorStatus::Failed;
+    result.message = "VDR failed to move the recording directory.";
+    return result;
+  }
+
+  if (pathExists(oldName) || !pathExists(targetFile)) {
+    result.status = RecordingMoveExecutorStatus::Failed;
+    result.message = "Recording move postcondition verification failed.";
+    return result;
+  }
+
+  Recordings->Del(recording);
+  Recordings->AddByName(targetFile.c_str());
+
+  const cRecording* movedRecording = Recordings->GetByName(targetFile.c_str());
+  if (!movedRecording) {
+    result.status = RecordingMoveExecutorStatus::Failed;
+    result.message = "Moved recording was not registered under its target identity.";
+    return result;
+  }
+
+  cRecordingUserCommand::InvokeCommand(
+    *cString::sprintf("rename \"%s\"", *strescape(oldName.c_str(), "\\\"$'")),
+    targetFile.c_str());
+
+  cVideoDiskUsage::ForceCheck();
+  StateChangeTracker::UpdateRecordings();
+
+  result.status = RecordingMoveExecutorStatus::Moved;
+  result.message = "Recording moved to the requested target.";
+  return result;
+}
+
+const char* RecordingMoveExecutorStatusName(RecordingMoveExecutorStatus status)
+{
+  switch (status) {
+    case RecordingMoveExecutorStatus::Moved:
+      return "moved";
+    case RecordingMoveExecutorStatus::AlreadyMoved:
+      return "already-moved";
+    case RecordingMoveExecutorStatus::Conflict:
+      return "conflict";
+    case RecordingMoveExecutorStatus::Blocked:
+      return "blocked";
+    case RecordingMoveExecutorStatus::NotFound:
+      return "not-found";
+    case RecordingMoveExecutorStatus::Failed:
+      return "failed";
+  }
+
+  return "failed";
+}

--- a/recordingmoveexecutor.h
+++ b/recordingmoveexecutor.h
@@ -1,0 +1,44 @@
+#ifndef __RECORDINGMOVEEXECUTOR_H
+#define __RECORDINGMOVEEXECUTOR_H
+
+#include "recordingmoveexecution.h"
+
+#include <string>
+
+enum class RecordingMoveExecutorStatus
+{
+  Moved,
+  AlreadyMoved,
+  Conflict,
+  Blocked,
+  NotFound,
+  Failed
+};
+
+struct RecordingMoveExecutorResult
+{
+  RecordingMoveExecutorStatus status = RecordingMoveExecutorStatus::Failed;
+  std::string recordingFile;
+  std::string targetFile;
+  std::string message;
+  RecordingMoveExecutionGateResult gate;
+};
+
+class RecordingMoveExecutor
+{
+public:
+  explicit RecordingMoveExecutor(const RecordingMoveExecutionGate& gate);
+
+  RecordingMoveExecutorResult executeNormalCase(
+    const std::string& recordingFile,
+    const std::string& targetFile,
+    const RecordingMutationRevision& expectedRevision,
+    const RecordingMutationPolicy& policy) const;
+
+private:
+  const RecordingMoveExecutionGate& gate;
+};
+
+const char* RecordingMoveExecutorStatusName(RecordingMoveExecutorStatus status);
+
+#endif

--- a/recordingmovepreflight.cpp
+++ b/recordingmovepreflight.cpp
@@ -1,0 +1,46 @@
+#include "recordingpreflight.h"
+
+namespace {
+
+void appendMoveAnalysisAndPlan(
+  RecordingMovePreflightResult& result,
+  const RecordingMutationAnalysis& analysis,
+  const RecordingMutationPlan& plan)
+{
+  result.executable = plan.executable;
+  result.recordingFile = analysis.recordingFile;
+  result.targetFile = analysis.targetFile;
+  result.warnings = plan.warnings;
+  result.revision = plan.expectedRevision;
+
+  for (const RecordingConstraint constraint : analysis.constraints)
+    result.constraints.push_back(RecordingConstraintName(constraint));
+
+  for (const RecordingConstraint blocker : plan.blockers)
+    result.blockers.push_back(RecordingConstraintName(blocker));
+
+  for (const RecordingMutationStep step : plan.steps)
+    result.steps.push_back(RecordingMutationStepName(step));
+}
+
+}
+
+RecordingMovePreflightService::RecordingMovePreflightService(
+  const RecordingMoveAnalyzer& analyzer,
+  const RecordingMutationPlanner& planner)
+  : analyzer(analyzer),
+    planner(planner)
+{
+}
+
+RecordingMovePreflightResult RecordingMovePreflightService::preview(
+  const std::string& recordingFile,
+  const std::string& targetFile,
+  const RecordingMutationPolicy& policy) const
+{
+  RecordingMovePreflightResult result;
+  const RecordingMutationAnalysis analysis = analyzer.analyze(recordingFile, targetFile);
+  const RecordingMutationPlan plan = planner.buildMovePlan(analysis, policy);
+  appendMoveAnalysisAndPlan(result, analysis, plan);
+  return result;
+}

--- a/recordingmovepreview.cpp
+++ b/recordingmovepreview.cpp
@@ -1,0 +1,83 @@
+#include "recordingmovepreview.h"
+
+#include "recordinganalysis.h"
+#include "recordingmutation.h"
+#include "recordingpreflight.h"
+#include "tools.h"
+
+#include <cxxtools/jsonserializer.h>
+
+void RecordingMovePreviewResponder::reply(
+  std::ostream& out,
+  cxxtools::http::Request& request,
+  cxxtools::http::Reply& reply)
+{
+  QueryHandler::addHeader(reply);
+
+  if (request.method() == "OPTIONS") {
+    reply.addHeader("Allow", "POST");
+    reply.httpReturn(200, "OK");
+    return;
+  }
+
+  if (request.method() != "POST") {
+    reply.httpReturn(501, "Only POST method is supported by the /recordings/move/preview service.");
+    return;
+  }
+
+  QueryHandler query("/recordings/move/preview", request);
+  const std::string recordingFile = query.getBodyAsString("file");
+  const std::string targetFile = query.getBodyAsString("target_file");
+
+  if (recordingFile.empty()) {
+    reply.httpReturn(400, "Recording file is missing.");
+    return;
+  }
+
+  if (targetFile.empty()) {
+    reply.httpReturn(400, "Recording move target file is missing.");
+    return;
+  }
+
+  RecordingMutationPolicy policy;
+  policy.allowRecordingHandlerStop = query.getBodyAsBool("allow_recording_handler_stop");
+  policy.allowReplayStop = query.getBodyAsBool("allow_replay_stop");
+  policy.allowLocalTimerStop = query.getBodyAsBool("allow_local_timer_stop");
+  policy.allowRemoteTimerStop = query.getBodyAsBool("allow_remote_timer_stop");
+
+  VdrRecordingLookup recordingLookup;
+  VdrRecordingReplayLookup replayLookup;
+  VdrRecordingHandlerLookup recordingHandlerLookup;
+  VdrRecordingLocalTimerLookup localTimerLookup;
+  VdrRecordingRemoteTimerLookup remoteTimerLookup;
+  VdrRecordingSearchTimerLookup searchTimerLookup;
+
+  RecordingMoveAnalyzer analyzer(
+    recordingLookup,
+    replayLookup,
+    recordingHandlerLookup,
+    localTimerLookup,
+    remoteTimerLookup,
+    searchTimerLookup);
+
+  RecordingMutationPlanner planner;
+  RecordingMovePreflightService preflightService(analyzer, planner);
+  const RecordingMovePreflightResult result =
+    preflightService.preview(recordingFile, targetFile, policy);
+
+  reply.addHeader("Content-Type", "application/json; charset=utf-8");
+
+  cxxtools::JsonSerializer serializer(out);
+  serializer.serialize(result.executable, "executable");
+  serializer.serialize(result.recordingFile, "recording_file");
+  serializer.serialize(result.targetFile, "target_file");
+  serializer.serialize(result.constraints, "constraints");
+  serializer.serialize(result.blockers, "blockers");
+  serializer.serialize(result.warnings, "warnings");
+  serializer.serialize(result.steps, "steps");
+  serializer.serialize(result.revision.recordingFile, "revision_recording_file");
+  serializer.serialize(result.revision.targetFile, "revision_target_file");
+  serializer.serialize(result.revision.recordingsState, "revision_recordings_state");
+  serializer.serialize(result.revision.timersState, "revision_timers_state");
+  serializer.finish();
+}

--- a/recordingmovepreview.h
+++ b/recordingmovepreview.h
@@ -1,0 +1,25 @@
+#ifndef __RECORDINGMOVEPREVIEW_H
+#define __RECORDINGMOVEPREVIEW_H
+
+#include <cxxtools/http/reply.h>
+#include <cxxtools/http/request.h>
+#include <cxxtools/http/responder.h>
+
+class RecordingMovePreviewResponder : public cxxtools::http::Responder
+{
+public:
+  explicit RecordingMovePreviewResponder(cxxtools::http::Service& service)
+    : cxxtools::http::Responder(service)
+  {
+  }
+
+  void reply(
+    std::ostream& out,
+    cxxtools::http::Request& request,
+    cxxtools::http::Reply& reply) override;
+};
+
+typedef cxxtools::http::CachedService<RecordingMovePreviewResponder>
+  RecordingMovePreviewService;
+
+#endif

--- a/recordingmovevalidate.cpp
+++ b/recordingmovevalidate.cpp
@@ -1,0 +1,153 @@
+#include "recordingmovevalidate.h"
+
+#include "recordinganalysis.h"
+#include "recordingmoveexecution.h"
+#include "recordingmutation.h"
+#include "tools.h"
+
+#include <cxxtools/jsonserializer.h>
+
+#include <string>
+
+namespace {
+
+bool parseLongLong(const std::string& value, long long& result)
+{
+  if (value.empty())
+    return false;
+
+  try {
+    std::size_t parsed = 0;
+    result = std::stoll(value, &parsed, 10);
+    return parsed == value.size();
+  }
+  catch (...) {
+    return false;
+  }
+}
+
+std::vector<std::string> constraintNames(
+  const std::vector<RecordingConstraint>& constraints)
+{
+  std::vector<std::string> names;
+  for (RecordingConstraint constraint : constraints)
+    names.push_back(RecordingConstraintName(constraint));
+  return names;
+}
+
+}
+
+void RecordingMoveValidateResponder::reply(
+  std::ostream& out,
+  cxxtools::http::Request& request,
+  cxxtools::http::Reply& reply)
+{
+  QueryHandler::addHeader(reply);
+
+  if (request.method() == "OPTIONS") {
+    reply.addHeader("Allow", "POST");
+    reply.httpReturn(200, "OK");
+    return;
+  }
+
+  if (request.method() != "POST") {
+    reply.httpReturn(501, "Only POST method is supported by the /recordings/move/validate service.");
+    return;
+  }
+
+  QueryHandler query("/recordings/move/validate", request);
+  const std::string recordingFile = query.getBodyAsString("file");
+  const std::string targetFile = query.getBodyAsString("target_file");
+  const std::string recordingsStateText =
+    query.getBodyAsString("revision_recordings_state");
+  const std::string timersStateText =
+    query.getBodyAsString("revision_timers_state");
+
+  long long recordingsState = 0;
+  long long timersState = 0;
+
+  if (recordingFile.empty()) {
+    reply.httpReturn(400, "Recording file is missing.");
+    return;
+  }
+
+  if (targetFile.empty()) {
+    reply.httpReturn(400, "Recording move target file is missing.");
+    return;
+  }
+
+  if (!parseLongLong(recordingsStateText, recordingsState) ||
+      !parseLongLong(timersStateText, timersState)) {
+    reply.httpReturn(400, "Recording move revision is missing or invalid.");
+    return;
+  }
+
+  RecordingMutationPolicy policy;
+  policy.allowRecordingHandlerStop = query.getBodyAsBool("allow_recording_handler_stop");
+  policy.allowReplayStop = query.getBodyAsBool("allow_replay_stop");
+  policy.allowLocalTimerStop = query.getBodyAsBool("allow_local_timer_stop");
+  policy.allowRemoteTimerStop = query.getBodyAsBool("allow_remote_timer_stop");
+
+  VdrRecordingLookup recordingLookup;
+  VdrRecordingReplayLookup replayLookup;
+  VdrRecordingHandlerLookup recordingHandlerLookup;
+  VdrRecordingLocalTimerLookup localTimerLookup;
+  VdrRecordingRemoteTimerLookup remoteTimerLookup;
+  VdrRecordingSearchTimerLookup searchTimerLookup;
+
+  RecordingMoveAnalyzer analyzer(
+    recordingLookup,
+    replayLookup,
+    recordingHandlerLookup,
+    localTimerLookup,
+    remoteTimerLookup,
+    searchTimerLookup);
+
+  RecordingMutationPlanner planner;
+  RecordingMoveExecutionGate gate(analyzer, planner);
+
+  RecordingMutationRevision expectedRevision;
+  expectedRevision.recordingFile = recordingFile;
+  expectedRevision.targetFile = targetFile;
+  expectedRevision.recordingsState = recordingsState;
+  expectedRevision.timersState = timersState;
+
+  const RecordingMoveExecutionGateResult result =
+    gate.validate(recordingFile, targetFile, expectedRevision, policy);
+
+  reply.addHeader("Content-Type", "application/json; charset=utf-8");
+
+  cxxtools::JsonSerializer serializer(out);
+  serializer.serialize(
+    std::string(RecordingMoveExecutionGateStatusName(result.status)),
+    "status");
+  serializer.serialize(result.recordingFile, "recording_file");
+  serializer.serialize(result.targetFile, "target_file");
+  serializer.serialize(constraintNames(result.blockers), "blockers");
+  serializer.serialize(result.warnings, "warnings");
+  serializer.serialize(
+    result.expectedRevision.recordingFile,
+    "expected_revision_recording_file");
+  serializer.serialize(
+    result.expectedRevision.targetFile,
+    "expected_revision_target_file");
+  serializer.serialize(
+    result.expectedRevision.recordingsState,
+    "expected_revision_recordings_state");
+  serializer.serialize(
+    result.expectedRevision.timersState,
+    "expected_revision_timers_state");
+  serializer.serialize(
+    result.currentRevision.recordingFile,
+    "current_revision_recording_file");
+  serializer.serialize(
+    result.currentRevision.targetFile,
+    "current_revision_target_file");
+  serializer.serialize(
+    result.currentRevision.recordingsState,
+    "current_revision_recordings_state");
+  serializer.serialize(
+    result.currentRevision.timersState,
+    "current_revision_timers_state");
+  serializer.finish();
+}

--- a/recordingmovevalidate.h
+++ b/recordingmovevalidate.h
@@ -1,0 +1,25 @@
+#ifndef __RECORDINGMOVEVALIDATE_H
+#define __RECORDINGMOVEVALIDATE_H
+
+#include <cxxtools/http/request.h>
+#include <cxxtools/http/reply.h>
+#include <cxxtools/http/responder.h>
+
+class RecordingMoveValidateResponder : public cxxtools::http::Responder
+{
+public:
+  explicit RecordingMoveValidateResponder(cxxtools::http::Service& service)
+    : cxxtools::http::Responder(service)
+  {
+  }
+
+  void reply(
+    std::ostream& out,
+    cxxtools::http::Request& request,
+    cxxtools::http::Reply& reply) override;
+};
+
+typedef cxxtools::http::CachedService<RecordingMoveValidateResponder>
+  RecordingMoveValidateService;
+
+#endif

--- a/recordingmutation.cpp
+++ b/recordingmutation.cpp
@@ -21,20 +21,11 @@ void addStep(RecordingMutationPlan& plan, RecordingMutationStep step)
     plan.steps.push_back(step);
 }
 
-}
-
-RecordingMutationPlan RecordingMutationPlanner::buildTrashPlan(
+void addCommonSafetyConstraints(
+  RecordingMutationPlan& plan,
   const RecordingMutationAnalysis& analysis,
-  const RecordingMutationPolicy& policy) const
+  const RecordingMutationPolicy& policy)
 {
-  RecordingMutationPlan plan;
-  plan.type = RecordingMutationType::Trash;
-  plan.warnings = analysis.warnings;
-  plan.expectedRevision = analysis.revision;
-
-  if (analysis.type != RecordingMutationType::Trash)
-    addBlocker(plan, RecordingConstraint::RecordingMissing);
-
   if (analysis.hasConstraint(RecordingConstraint::RecordingMissing))
     addBlocker(plan, RecordingConstraint::RecordingMissing);
 
@@ -80,9 +71,64 @@ RecordingMutationPlan RecordingMutationPlanner::buildTrashPlan(
 
   if (analysis.hasConstraint(RecordingConstraint::SearchTimerRecording))
     plan.warnings.push_back("EPGSearch may classify an interrupted recording as incomplete.");
+}
+
+}
+
+RecordingMutationPlan RecordingMutationPlanner::buildTrashPlan(
+  const RecordingMutationAnalysis& analysis,
+  const RecordingMutationPolicy& policy) const
+{
+  RecordingMutationPlan plan;
+  plan.type = RecordingMutationType::Trash;
+  plan.warnings = analysis.warnings;
+  plan.expectedRevision = analysis.revision;
+
+  if (analysis.type != RecordingMutationType::Trash)
+    addBlocker(plan, RecordingConstraint::RecordingMissing);
+
+  addCommonSafetyConstraints(plan, analysis, policy);
 
   if (plan.blockers.empty()) {
     addStep(plan, RecordingMutationStep::TrashRecording);
+    addStep(plan, RecordingMutationStep::RefreshRecordings);
+    addStep(plan, RecordingMutationStep::NotifyChange);
+    plan.executable = true;
+  }
+
+  return plan;
+}
+
+RecordingMutationPlan RecordingMutationPlanner::buildMovePlan(
+  const RecordingMutationAnalysis& analysis,
+  const RecordingMutationPolicy& policy) const
+{
+  RecordingMutationPlan plan;
+  plan.type = RecordingMutationType::Move;
+  plan.warnings = analysis.warnings;
+  plan.expectedRevision = analysis.revision;
+
+  if (analysis.type != RecordingMutationType::Move)
+    addBlocker(plan, RecordingConstraint::RecordingMissing);
+
+  addCommonSafetyConstraints(plan, analysis, policy);
+
+  if (analysis.targetFile.empty() ||
+      analysis.hasConstraint(RecordingConstraint::MoveTargetMissing))
+    addBlocker(plan, RecordingConstraint::MoveTargetMissing);
+
+  if (analysis.hasConstraint(RecordingConstraint::MoveTargetInvalid))
+    addBlocker(plan, RecordingConstraint::MoveTargetInvalid);
+
+  if (analysis.recordingFile == analysis.targetFile ||
+      analysis.hasConstraint(RecordingConstraint::MoveTargetSameAsSource))
+    addBlocker(plan, RecordingConstraint::MoveTargetSameAsSource);
+
+  if (analysis.hasConstraint(RecordingConstraint::MoveTargetExists))
+    addBlocker(plan, RecordingConstraint::MoveTargetExists);
+
+  if (plan.blockers.empty()) {
+    addStep(plan, RecordingMutationStep::MoveRecording);
     addStep(plan, RecordingMutationStep::RefreshRecordings);
     addStep(plan, RecordingMutationStep::NotifyChange);
     plan.executable = true;
@@ -104,6 +150,10 @@ const char* RecordingConstraintName(RecordingConstraint constraint)
     case RecordingConstraint::UnknownLocalTimerState: return "unknown-local-timer-state";
     case RecordingConstraint::UnknownRemoteTimerState: return "unknown-remote-timer-state";
     case RecordingConstraint::UnknownSearchTimerState: return "unknown-searchtimer-state";
+    case RecordingConstraint::MoveTargetMissing: return "move-target-missing";
+    case RecordingConstraint::MoveTargetInvalid: return "move-target-invalid";
+    case RecordingConstraint::MoveTargetSameAsSource: return "move-target-same-as-source";
+    case RecordingConstraint::MoveTargetExists: return "move-target-exists";
   }
   return "unknown";
 }
@@ -118,6 +168,7 @@ const char* RecordingMutationStepName(RecordingMutationStep step)
     case RecordingMutationStep::TrashRecording: return "trash-recording";
     case RecordingMutationStep::RestoreRecording: return "restore-recording";
     case RecordingMutationStep::PurgeRecording: return "purge-recording";
+    case RecordingMutationStep::MoveRecording: return "move-recording";
     case RecordingMutationStep::RefreshRecordings: return "refresh-recordings";
     case RecordingMutationStep::NotifyChange: return "notify-change";
   }

--- a/recordingmutation.cpp
+++ b/recordingmutation.cpp
@@ -1,0 +1,117 @@
+#include "recordingmutation.h"
+
+#include <algorithm>
+
+bool RecordingMutationAnalysis::hasConstraint(RecordingConstraint constraint) const
+{
+  return std::find(constraints.begin(), constraints.end(), constraint) != constraints.end();
+}
+
+namespace {
+
+void addBlocker(RecordingMutationPlan& plan, RecordingConstraint constraint)
+{
+  if (std::find(plan.blockers.begin(), plan.blockers.end(), constraint) == plan.blockers.end())
+    plan.blockers.push_back(constraint);
+}
+
+void addStep(RecordingMutationPlan& plan, RecordingMutationStep step)
+{
+  if (std::find(plan.steps.begin(), plan.steps.end(), step) == plan.steps.end())
+    plan.steps.push_back(step);
+}
+
+}
+
+RecordingMutationPlan RecordingMutationPlanner::buildTrashPlan(
+  const RecordingMutationAnalysis& analysis,
+  const RecordingMutationPolicy& policy) const
+{
+  RecordingMutationPlan plan;
+  plan.type = RecordingMutationType::Trash;
+  plan.warnings = analysis.warnings;
+  plan.expectedRevision = analysis.revision;
+
+  if (analysis.type != RecordingMutationType::Trash)
+    addBlocker(plan, RecordingConstraint::RecordingMissing);
+
+  if (analysis.hasConstraint(RecordingConstraint::RecordingMissing))
+    addBlocker(plan, RecordingConstraint::RecordingMissing);
+
+  if (analysis.hasConstraint(RecordingConstraint::UnknownTimerState))
+    addBlocker(plan, RecordingConstraint::UnknownTimerState);
+
+  if (analysis.hasConstraint(RecordingConstraint::UnknownSearchTimerState))
+    addBlocker(plan, RecordingConstraint::UnknownSearchTimerState);
+
+  if (analysis.hasConstraint(RecordingConstraint::RecordingHandlerBusy)) {
+    if (policy.allowRecordingHandlerStop)
+      addStep(plan, RecordingMutationStep::StopRecordingHandler);
+    else
+      addBlocker(plan, RecordingConstraint::RecordingHandlerBusy);
+  }
+
+  if (analysis.hasConstraint(RecordingConstraint::ReplayActive)) {
+    if (policy.allowReplayStop)
+      addStep(plan, RecordingMutationStep::StopReplay);
+    else
+      addBlocker(plan, RecordingConstraint::ReplayActive);
+  }
+
+  if (analysis.hasConstraint(RecordingConstraint::LocalTimerActive)) {
+    if (policy.allowLocalTimerStop)
+      addStep(plan, RecordingMutationStep::DeactivateLocalTimer);
+    else
+      addBlocker(plan, RecordingConstraint::LocalTimerActive);
+  }
+
+  if (analysis.hasConstraint(RecordingConstraint::RemoteTimerActive)) {
+    if (policy.allowRemoteTimerStop)
+      addStep(plan, RecordingMutationStep::DeactivateRemoteTimer);
+    else
+      addBlocker(plan, RecordingConstraint::RemoteTimerActive);
+  }
+
+  if (analysis.hasConstraint(RecordingConstraint::SearchTimerRecording))
+    plan.warnings.push_back("EPGSearch may classify an interrupted recording as incomplete.");
+
+  if (plan.blockers.empty()) {
+    addStep(plan, RecordingMutationStep::TrashRecording);
+    addStep(plan, RecordingMutationStep::RefreshRecordings);
+    addStep(plan, RecordingMutationStep::NotifyChange);
+    plan.executable = true;
+  }
+
+  return plan;
+}
+
+const char* RecordingConstraintName(RecordingConstraint constraint)
+{
+  switch (constraint) {
+    case RecordingConstraint::RecordingMissing: return "recording-missing";
+    case RecordingConstraint::RecordingHandlerBusy: return "recording-handler-busy";
+    case RecordingConstraint::ReplayActive: return "replay-active";
+    case RecordingConstraint::LocalTimerActive: return "local-timer-active";
+    case RecordingConstraint::RemoteTimerActive: return "remote-timer-active";
+    case RecordingConstraint::SearchTimerRecording: return "searchtimer-recording";
+    case RecordingConstraint::UnknownTimerState: return "unknown-timer-state";
+    case RecordingConstraint::UnknownSearchTimerState: return "unknown-searchtimer-state";
+  }
+  return "unknown";
+}
+
+const char* RecordingMutationStepName(RecordingMutationStep step)
+{
+  switch (step) {
+    case RecordingMutationStep::StopRecordingHandler: return "stop-recording-handler";
+    case RecordingMutationStep::StopReplay: return "stop-replay";
+    case RecordingMutationStep::DeactivateLocalTimer: return "deactivate-local-timer";
+    case RecordingMutationStep::DeactivateRemoteTimer: return "deactivate-remote-timer";
+    case RecordingMutationStep::TrashRecording: return "trash-recording";
+    case RecordingMutationStep::RestoreRecording: return "restore-recording";
+    case RecordingMutationStep::PurgeRecording: return "purge-recording";
+    case RecordingMutationStep::RefreshRecordings: return "refresh-recordings";
+    case RecordingMutationStep::NotifyChange: return "notify-change";
+  }
+  return "unknown";
+}

--- a/recordingmutation.cpp
+++ b/recordingmutation.cpp
@@ -41,8 +41,11 @@ RecordingMutationPlan RecordingMutationPlanner::buildTrashPlan(
   if (analysis.hasConstraint(RecordingConstraint::UnknownRecordingHandlerState))
     addBlocker(plan, RecordingConstraint::UnknownRecordingHandlerState);
 
-  if (analysis.hasConstraint(RecordingConstraint::UnknownTimerState))
-    addBlocker(plan, RecordingConstraint::UnknownTimerState);
+  if (analysis.hasConstraint(RecordingConstraint::UnknownLocalTimerState))
+    addBlocker(plan, RecordingConstraint::UnknownLocalTimerState);
+
+  if (analysis.hasConstraint(RecordingConstraint::UnknownRemoteTimerState))
+    addBlocker(plan, RecordingConstraint::UnknownRemoteTimerState);
 
   if (analysis.hasConstraint(RecordingConstraint::UnknownSearchTimerState))
     addBlocker(plan, RecordingConstraint::UnknownSearchTimerState);
@@ -98,7 +101,8 @@ const char* RecordingConstraintName(RecordingConstraint constraint)
     case RecordingConstraint::RemoteTimerActive: return "remote-timer-active";
     case RecordingConstraint::SearchTimerRecording: return "searchtimer-recording";
     case RecordingConstraint::UnknownRecordingHandlerState: return "unknown-recording-handler-state";
-    case RecordingConstraint::UnknownTimerState: return "unknown-timer-state";
+    case RecordingConstraint::UnknownLocalTimerState: return "unknown-local-timer-state";
+    case RecordingConstraint::UnknownRemoteTimerState: return "unknown-remote-timer-state";
     case RecordingConstraint::UnknownSearchTimerState: return "unknown-searchtimer-state";
   }
   return "unknown";

--- a/recordingmutation.cpp
+++ b/recordingmutation.cpp
@@ -38,6 +38,9 @@ RecordingMutationPlan RecordingMutationPlanner::buildTrashPlan(
   if (analysis.hasConstraint(RecordingConstraint::RecordingMissing))
     addBlocker(plan, RecordingConstraint::RecordingMissing);
 
+  if (analysis.hasConstraint(RecordingConstraint::UnknownRecordingHandlerState))
+    addBlocker(plan, RecordingConstraint::UnknownRecordingHandlerState);
+
   if (analysis.hasConstraint(RecordingConstraint::UnknownTimerState))
     addBlocker(plan, RecordingConstraint::UnknownTimerState);
 
@@ -94,6 +97,7 @@ const char* RecordingConstraintName(RecordingConstraint constraint)
     case RecordingConstraint::LocalTimerActive: return "local-timer-active";
     case RecordingConstraint::RemoteTimerActive: return "remote-timer-active";
     case RecordingConstraint::SearchTimerRecording: return "searchtimer-recording";
+    case RecordingConstraint::UnknownRecordingHandlerState: return "unknown-recording-handler-state";
     case RecordingConstraint::UnknownTimerState: return "unknown-timer-state";
     case RecordingConstraint::UnknownSearchTimerState: return "unknown-searchtimer-state";
   }

--- a/recordingmutation.h
+++ b/recordingmutation.h
@@ -1,0 +1,88 @@
+#ifndef __RECORDINGMUTATION_H
+#define __RECORDINGMUTATION_H
+
+#include <string>
+#include <vector>
+
+enum class RecordingMutationType
+{
+  Trash,
+  Restore,
+  Purge,
+  Move,
+  Rename
+};
+
+enum class RecordingConstraint
+{
+  RecordingMissing,
+  RecordingHandlerBusy,
+  ReplayActive,
+  LocalTimerActive,
+  RemoteTimerActive,
+  SearchTimerRecording,
+  UnknownTimerState,
+  UnknownSearchTimerState
+};
+
+enum class RecordingMutationStep
+{
+  StopRecordingHandler,
+  StopReplay,
+  DeactivateLocalTimer,
+  DeactivateRemoteTimer,
+  TrashRecording,
+  RestoreRecording,
+  PurgeRecording,
+  RefreshRecordings,
+  NotifyChange
+};
+
+struct RecordingMutationRevision
+{
+  std::string recordingFile;
+  long long recordingsState = 0;
+  long long timersState = 0;
+};
+
+struct RecordingMutationAnalysis
+{
+  RecordingMutationType type = RecordingMutationType::Trash;
+  std::string recordingFile;
+  std::vector<RecordingConstraint> constraints;
+  std::vector<std::string> warnings;
+  RecordingMutationRevision revision;
+
+  bool hasConstraint(RecordingConstraint constraint) const;
+};
+
+struct RecordingMutationPolicy
+{
+  bool allowRecordingHandlerStop = false;
+  bool allowReplayStop = false;
+  bool allowLocalTimerStop = false;
+  bool allowRemoteTimerStop = false;
+};
+
+struct RecordingMutationPlan
+{
+  RecordingMutationType type = RecordingMutationType::Trash;
+  bool executable = false;
+  std::vector<RecordingMutationStep> steps;
+  std::vector<RecordingConstraint> blockers;
+  std::vector<std::string> warnings;
+  RecordingMutationRevision expectedRevision;
+};
+
+class RecordingMutationPlanner
+{
+public:
+  RecordingMutationPlan buildTrashPlan(
+    const RecordingMutationAnalysis& analysis,
+    const RecordingMutationPolicy& policy) const;
+};
+
+const char* RecordingConstraintName(RecordingConstraint constraint);
+const char* RecordingMutationStepName(RecordingMutationStep step);
+
+#endif

--- a/recordingmutation.h
+++ b/recordingmutation.h
@@ -22,7 +22,8 @@ enum class RecordingConstraint
   RemoteTimerActive,
   SearchTimerRecording,
   UnknownRecordingHandlerState,
-  UnknownTimerState,
+  UnknownLocalTimerState,
+  UnknownRemoteTimerState,
   UnknownSearchTimerState
 };
 

--- a/recordingmutation.h
+++ b/recordingmutation.h
@@ -21,6 +21,7 @@ enum class RecordingConstraint
   LocalTimerActive,
   RemoteTimerActive,
   SearchTimerRecording,
+  UnknownRecordingHandlerState,
   UnknownTimerState,
   UnknownSearchTimerState
 };

--- a/recordingmutation.h
+++ b/recordingmutation.h
@@ -24,7 +24,11 @@ enum class RecordingConstraint
   UnknownRecordingHandlerState,
   UnknownLocalTimerState,
   UnknownRemoteTimerState,
-  UnknownSearchTimerState
+  UnknownSearchTimerState,
+  MoveTargetMissing,
+  MoveTargetInvalid,
+  MoveTargetSameAsSource,
+  MoveTargetExists
 };
 
 enum class RecordingMutationStep
@@ -36,6 +40,7 @@ enum class RecordingMutationStep
   TrashRecording,
   RestoreRecording,
   PurgeRecording,
+  MoveRecording,
   RefreshRecordings,
   NotifyChange
 };
@@ -43,6 +48,7 @@ enum class RecordingMutationStep
 struct RecordingMutationRevision
 {
   std::string recordingFile;
+  std::string targetFile;
   long long recordingsState = 0;
   long long timersState = 0;
 };
@@ -51,6 +57,7 @@ struct RecordingMutationAnalysis
 {
   RecordingMutationType type = RecordingMutationType::Trash;
   std::string recordingFile;
+  std::string targetFile;
   std::vector<RecordingConstraint> constraints;
   std::vector<std::string> warnings;
   RecordingMutationRevision revision;
@@ -80,6 +87,10 @@ class RecordingMutationPlanner
 {
 public:
   RecordingMutationPlan buildTrashPlan(
+    const RecordingMutationAnalysis& analysis,
+    const RecordingMutationPolicy& policy) const;
+
+  RecordingMutationPlan buildMovePlan(
     const RecordingMutationAnalysis& analysis,
     const RecordingMutationPolicy& policy) const;
 };

--- a/recordingpreflight.cpp
+++ b/recordingpreflight.cpp
@@ -2,9 +2,8 @@
 
 namespace {
 
-template <typename Result>
-void appendAnalysisAndPlan(
-  Result& result,
+void appendTrashAnalysisAndPlan(
+  RecordingTrashPreflightResult& result,
   const RecordingMutationAnalysis& analysis,
   const RecordingMutationPlan& plan)
 {
@@ -40,27 +39,6 @@ RecordingTrashPreflightResult RecordingTrashPreflightService::preview(
   RecordingTrashPreflightResult result;
   const RecordingMutationAnalysis analysis = analyzer.analyze(recordingFile);
   const RecordingMutationPlan plan = planner.buildTrashPlan(analysis, policy);
-  appendAnalysisAndPlan(result, analysis, plan);
-  return result;
-}
-
-RecordingMovePreflightService::RecordingMovePreflightService(
-  const RecordingMoveAnalyzer& analyzer,
-  const RecordingMutationPlanner& planner)
-  : analyzer(analyzer),
-    planner(planner)
-{
-}
-
-RecordingMovePreflightResult RecordingMovePreflightService::preview(
-  const std::string& recordingFile,
-  const std::string& targetFile,
-  const RecordingMutationPolicy& policy) const
-{
-  RecordingMovePreflightResult result;
-  const RecordingMutationAnalysis analysis = analyzer.analyze(recordingFile, targetFile);
-  const RecordingMutationPlan plan = planner.buildMovePlan(analysis, policy);
-  appendAnalysisAndPlan(result, analysis, plan);
-  result.targetFile = analysis.targetFile;
+  appendTrashAnalysisAndPlan(result, analysis, plan);
   return result;
 }

--- a/recordingpreflight.cpp
+++ b/recordingpreflight.cpp
@@ -1,0 +1,34 @@
+#include "recordingpreflight.h"
+
+RecordingTrashPreflightService::RecordingTrashPreflightService(
+  const RecordingTrashAnalyzer& analyzer,
+  const RecordingMutationPlanner& planner)
+  : analyzer(analyzer),
+    planner(planner)
+{
+}
+
+RecordingTrashPreflightResult RecordingTrashPreflightService::preview(
+  const std::string& recordingFile,
+  const RecordingMutationPolicy& policy) const
+{
+  RecordingTrashPreflightResult result;
+  const RecordingMutationAnalysis analysis = analyzer.analyze(recordingFile);
+  const RecordingMutationPlan plan = planner.buildTrashPlan(analysis, policy);
+
+  result.executable = plan.executable;
+  result.recordingFile = analysis.recordingFile;
+  result.warnings = plan.warnings;
+  result.revision = plan.expectedRevision;
+
+  for (const RecordingConstraint constraint : analysis.constraints)
+    result.constraints.push_back(RecordingConstraintName(constraint));
+
+  for (const RecordingConstraint blocker : plan.blockers)
+    result.blockers.push_back(RecordingConstraintName(blocker));
+
+  for (const RecordingMutationStep step : plan.steps)
+    result.steps.push_back(RecordingMutationStepName(step));
+
+  return result;
+}

--- a/recordingpreflight.cpp
+++ b/recordingpreflight.cpp
@@ -1,5 +1,30 @@
 #include "recordingpreflight.h"
 
+namespace {
+
+template <typename Result>
+void appendAnalysisAndPlan(
+  Result& result,
+  const RecordingMutationAnalysis& analysis,
+  const RecordingMutationPlan& plan)
+{
+  result.executable = plan.executable;
+  result.recordingFile = analysis.recordingFile;
+  result.warnings = plan.warnings;
+  result.revision = plan.expectedRevision;
+
+  for (const RecordingConstraint constraint : analysis.constraints)
+    result.constraints.push_back(RecordingConstraintName(constraint));
+
+  for (const RecordingConstraint blocker : plan.blockers)
+    result.blockers.push_back(RecordingConstraintName(blocker));
+
+  for (const RecordingMutationStep step : plan.steps)
+    result.steps.push_back(RecordingMutationStepName(step));
+}
+
+}
+
 RecordingTrashPreflightService::RecordingTrashPreflightService(
   const RecordingTrashAnalyzer& analyzer,
   const RecordingMutationPlanner& planner)
@@ -15,20 +40,27 @@ RecordingTrashPreflightResult RecordingTrashPreflightService::preview(
   RecordingTrashPreflightResult result;
   const RecordingMutationAnalysis analysis = analyzer.analyze(recordingFile);
   const RecordingMutationPlan plan = planner.buildTrashPlan(analysis, policy);
+  appendAnalysisAndPlan(result, analysis, plan);
+  return result;
+}
 
-  result.executable = plan.executable;
-  result.recordingFile = analysis.recordingFile;
-  result.warnings = plan.warnings;
-  result.revision = plan.expectedRevision;
+RecordingMovePreflightService::RecordingMovePreflightService(
+  const RecordingMoveAnalyzer& analyzer,
+  const RecordingMutationPlanner& planner)
+  : analyzer(analyzer),
+    planner(planner)
+{
+}
 
-  for (const RecordingConstraint constraint : analysis.constraints)
-    result.constraints.push_back(RecordingConstraintName(constraint));
-
-  for (const RecordingConstraint blocker : plan.blockers)
-    result.blockers.push_back(RecordingConstraintName(blocker));
-
-  for (const RecordingMutationStep step : plan.steps)
-    result.steps.push_back(RecordingMutationStepName(step));
-
+RecordingMovePreflightResult RecordingMovePreflightService::preview(
+  const std::string& recordingFile,
+  const std::string& targetFile,
+  const RecordingMutationPolicy& policy) const
+{
+  RecordingMovePreflightResult result;
+  const RecordingMutationAnalysis analysis = analyzer.analyze(recordingFile, targetFile);
+  const RecordingMutationPlan plan = planner.buildMovePlan(analysis, policy);
+  appendAnalysisAndPlan(result, analysis, plan);
+  result.targetFile = analysis.targetFile;
   return result;
 }

--- a/recordingpreflight.h
+++ b/recordingpreflight.h
@@ -1,0 +1,37 @@
+#ifndef __RECORDINGPREFLIGHT_H
+#define __RECORDINGPREFLIGHT_H
+
+#include "recordinganalysis.h"
+#include "recordingmutation.h"
+
+#include <string>
+#include <vector>
+
+struct RecordingTrashPreflightResult
+{
+  bool executable = false;
+  std::string recordingFile;
+  std::vector<std::string> constraints;
+  std::vector<std::string> blockers;
+  std::vector<std::string> warnings;
+  std::vector<std::string> steps;
+  RecordingMutationRevision revision;
+};
+
+class RecordingTrashPreflightService
+{
+public:
+  RecordingTrashPreflightService(
+    const RecordingTrashAnalyzer& analyzer,
+    const RecordingMutationPlanner& planner);
+
+  RecordingTrashPreflightResult preview(
+    const std::string& recordingFile,
+    const RecordingMutationPolicy& policy) const;
+
+private:
+  const RecordingTrashAnalyzer& analyzer;
+  const RecordingMutationPlanner& planner;
+};
+
+#endif

--- a/recordingpreflight.h
+++ b/recordingpreflight.h
@@ -18,6 +18,18 @@ struct RecordingTrashPreflightResult
   RecordingMutationRevision revision;
 };
 
+struct RecordingMovePreflightResult
+{
+  bool executable = false;
+  std::string recordingFile;
+  std::string targetFile;
+  std::vector<std::string> constraints;
+  std::vector<std::string> blockers;
+  std::vector<std::string> warnings;
+  std::vector<std::string> steps;
+  RecordingMutationRevision revision;
+};
+
 class RecordingTrashPreflightService
 {
 public:
@@ -31,6 +43,23 @@ public:
 
 private:
   const RecordingTrashAnalyzer& analyzer;
+  const RecordingMutationPlanner& planner;
+};
+
+class RecordingMovePreflightService
+{
+public:
+  RecordingMovePreflightService(
+    const RecordingMoveAnalyzer& analyzer,
+    const RecordingMutationPlanner& planner);
+
+  RecordingMovePreflightResult preview(
+    const std::string& recordingFile,
+    const std::string& targetFile,
+    const RecordingMutationPolicy& policy) const;
+
+private:
+  const RecordingMoveAnalyzer& analyzer;
   const RecordingMutationPlanner& planner;
 };
 

--- a/recordingpreview.cpp
+++ b/recordingpreview.cpp
@@ -1,0 +1,75 @@
+#include "recordingpreview.h"
+
+#include "recordinganalysis.h"
+#include "recordingmutation.h"
+#include "recordingpreflight.h"
+#include "tools.h"
+
+#include <cxxtools/jsonserializer.h>
+
+void RecordingTrashPreviewResponder::reply(
+  std::ostream& out,
+  cxxtools::http::Request& request,
+  cxxtools::http::Reply& reply)
+{
+  QueryHandler::addHeader(reply);
+
+  if (request.method() == "OPTIONS") {
+    reply.addHeader("Allow", "POST");
+    reply.httpReturn(200, "OK");
+    return;
+  }
+
+  if (request.method() != "POST") {
+    reply.httpReturn(501, "Only POST method is supported by the /recordings/trash/preview service.");
+    return;
+  }
+
+  QueryHandler query("/recordings/trash/preview", request);
+  const std::string recordingFile = query.getBodyAsString("file");
+
+  if (recordingFile.empty()) {
+    reply.httpReturn(400, "Recording file is missing.");
+    return;
+  }
+
+  RecordingMutationPolicy policy;
+  policy.allowRecordingHandlerStop = query.getBodyAsBool("allow_recording_handler_stop");
+  policy.allowReplayStop = query.getBodyAsBool("allow_replay_stop");
+  policy.allowLocalTimerStop = query.getBodyAsBool("allow_local_timer_stop");
+  policy.allowRemoteTimerStop = query.getBodyAsBool("allow_remote_timer_stop");
+
+  VdrRecordingLookup recordingLookup;
+  VdrRecordingReplayLookup replayLookup;
+  VdrRecordingHandlerLookup recordingHandlerLookup;
+  VdrRecordingLocalTimerLookup localTimerLookup;
+  VdrRecordingRemoteTimerLookup remoteTimerLookup;
+  VdrRecordingSearchTimerLookup searchTimerLookup;
+
+  RecordingTrashAnalyzer analyzer(
+    recordingLookup,
+    replayLookup,
+    recordingHandlerLookup,
+    localTimerLookup,
+    remoteTimerLookup,
+    searchTimerLookup);
+
+  RecordingMutationPlanner planner;
+  RecordingTrashPreflightService preflightService(analyzer, planner);
+  const RecordingTrashPreflightResult result =
+    preflightService.preview(recordingFile, policy);
+
+  reply.addHeader("Content-Type", "application/json; charset=utf-8");
+
+  cxxtools::JsonSerializer serializer(out);
+  serializer.serialize(result.executable, "executable");
+  serializer.serialize(result.recordingFile, "recording_file");
+  serializer.serialize(result.constraints, "constraints");
+  serializer.serialize(result.blockers, "blockers");
+  serializer.serialize(result.warnings, "warnings");
+  serializer.serialize(result.steps, "steps");
+  serializer.serialize(result.revision.recordingFile, "revision_recording_file");
+  serializer.serialize(result.revision.recordingsState, "revision_recordings_state");
+  serializer.serialize(result.revision.timersState, "revision_timers_state");
+  serializer.finish();
+}

--- a/recordingpreview.h
+++ b/recordingpreview.h
@@ -1,0 +1,25 @@
+#ifndef __RECORDINGPREVIEW_H
+#define __RECORDINGPREVIEW_H
+
+#include <cxxtools/http/reply.h>
+#include <cxxtools/http/request.h>
+#include <cxxtools/http/responder.h>
+
+class RecordingTrashPreviewResponder : public cxxtools::http::Responder
+{
+public:
+  explicit RecordingTrashPreviewResponder(cxxtools::http::Service& service)
+    : cxxtools::http::Responder(service)
+  {
+  }
+
+  void reply(
+    std::ostream& out,
+    cxxtools::http::Request& request,
+    cxxtools::http::Reply& reply) override;
+};
+
+typedef cxxtools::http::CachedService<RecordingTrashPreviewResponder>
+  RecordingTrashPreviewService;
+
+#endif

--- a/recordingtrash.cpp
+++ b/recordingtrash.cpp
@@ -1,0 +1,131 @@
+#include "recordingtrash.h"
+
+#include "recordinganalysis.h"
+#include "recordingexecution.h"
+#include "recordingmutation.h"
+#include "recordingtrashexecutor.h"
+#include "tools.h"
+
+#include <cxxtools/jsonserializer.h>
+
+#include <string>
+
+namespace {
+
+bool parseLongLong(const std::string& value, long long& result)
+{
+  if (value.empty())
+    return false;
+
+  try {
+    std::size_t parsed = 0;
+    result = std::stoll(value, &parsed, 10);
+    return parsed == value.size();
+  }
+  catch (...) {
+    return false;
+  }
+}
+
+}
+
+void RecordingTrashResponder::reply(
+  std::ostream& out,
+  cxxtools::http::Request& request,
+  cxxtools::http::Reply& reply)
+{
+  QueryHandler::addHeader(reply);
+
+  if (request.method() == "OPTIONS") {
+    reply.addHeader("Allow", "POST");
+    reply.httpReturn(200, "OK");
+    return;
+  }
+
+  if (request.method() != "POST") {
+    reply.httpReturn(501, "Only POST method is supported by the /recordings/trash service.");
+    return;
+  }
+
+  QueryHandler query("/recordings/trash", request);
+  const std::string recordingFile = query.getBodyAsString("file");
+  const std::string recordingsStateText =
+    query.getBodyAsString("revision_recordings_state");
+  const std::string timersStateText =
+    query.getBodyAsString("revision_timers_state");
+
+  long long recordingsState = 0;
+  long long timersState = 0;
+
+  if (recordingFile.empty()) {
+    reply.httpReturn(400, "Recording file is missing.");
+    return;
+  }
+
+  if (!parseLongLong(recordingsStateText, recordingsState) ||
+      !parseLongLong(timersStateText, timersState)) {
+    reply.httpReturn(400, "Recording revision is missing or invalid.");
+    return;
+  }
+
+  RecordingMutationPolicy policy;
+  policy.allowRecordingHandlerStop = false;
+  policy.allowReplayStop = false;
+  policy.allowLocalTimerStop = false;
+  policy.allowRemoteTimerStop = false;
+
+  VdrRecordingLookup recordingLookup;
+  VdrRecordingReplayLookup replayLookup;
+  VdrRecordingHandlerLookup recordingHandlerLookup;
+  VdrRecordingLocalTimerLookup localTimerLookup;
+  VdrRecordingRemoteTimerLookup remoteTimerLookup;
+  VdrRecordingSearchTimerLookup searchTimerLookup;
+
+  RecordingTrashAnalyzer analyzer(
+    recordingLookup,
+    replayLookup,
+    recordingHandlerLookup,
+    localTimerLookup,
+    remoteTimerLookup,
+    searchTimerLookup);
+
+  RecordingMutationPlanner planner;
+  RecordingTrashExecutionGate gate(analyzer, planner);
+  RecordingTrashExecutor executor(gate);
+
+  RecordingMutationRevision expectedRevision;
+  expectedRevision.recordingFile = recordingFile;
+  expectedRevision.recordingsState = recordingsState;
+  expectedRevision.timersState = timersState;
+
+  const RecordingTrashExecutorResult result =
+    executor.executeNormalCase(recordingFile, expectedRevision, policy);
+
+  switch (result.status) {
+    case RecordingTrashExecutorStatus::Conflict:
+      reply.httpReturn(409, result.message);
+      return;
+    case RecordingTrashExecutorStatus::Blocked:
+      reply.httpReturn(423, result.message);
+      return;
+    case RecordingTrashExecutorStatus::NotFound:
+      reply.httpReturn(404, result.message);
+      return;
+    case RecordingTrashExecutorStatus::Failed:
+      reply.httpReturn(500, result.message);
+      return;
+    case RecordingTrashExecutorStatus::Trashed:
+      break;
+  }
+
+  reply.addHeader("Content-Type", "application/json; charset=utf-8");
+
+  cxxtools::JsonSerializer serializer(out);
+  serializer.serialize(
+    std::string(RecordingTrashExecutorStatusName(result.status)),
+    "status");
+  serializer.serialize(result.recordingFile, "recording_file");
+  serializer.serialize(result.deletedRecordingFile, "deleted_recording_file");
+  serializer.serialize(result.message, "message");
+  serializer.finish();
+}

--- a/recordingtrash.cpp
+++ b/recordingtrash.cpp
@@ -115,6 +115,7 @@ void RecordingTrashResponder::reply(
       reply.httpReturn(500, result.message);
       return;
     case RecordingTrashExecutorStatus::Trashed:
+    case RecordingTrashExecutorStatus::AlreadyTrashed:
       break;
   }
 

--- a/recordingtrash.h
+++ b/recordingtrash.h
@@ -1,0 +1,25 @@
+#ifndef __RECORDINGTRASH_H
+#define __RECORDINGTRASH_H
+
+#include <cxxtools/http/request.h>
+#include <cxxtools/http/reply.h>
+#include <cxxtools/http/responder.h>
+
+class RecordingTrashResponder : public cxxtools::http::Responder
+{
+public:
+  explicit RecordingTrashResponder(cxxtools::http::Service& service)
+    : cxxtools::http::Responder(service)
+  {
+  }
+
+  void reply(
+    std::ostream& out,
+    cxxtools::http::Request& request,
+    cxxtools::http::Reply& reply) override;
+};
+
+typedef cxxtools::http::CachedService<RecordingTrashResponder>
+  RecordingTrashService;
+
+#endif

--- a/recordingtrashexecutor.cpp
+++ b/recordingtrashexecutor.cpp
@@ -1,0 +1,134 @@
+#include "recordingtrashexecutor.h"
+
+#include "changestatetracker.h"
+
+#include <cstring>
+
+#include <vdr/menu.h>
+#include <vdr/recording.h>
+
+namespace {
+
+std::string deletedFileName(const std::string& recordingFile)
+{
+  static const std::string recordingSuffix = ".rec";
+  if (recordingFile.size() >= recordingSuffix.size() &&
+      recordingFile.compare(
+        recordingFile.size() - recordingSuffix.size(),
+        recordingSuffix.size(),
+        recordingSuffix) == 0)
+    return recordingFile.substr(0, recordingFile.size() - recordingSuffix.size()) + ".del";
+
+  return std::string();
+}
+
+}
+
+RecordingTrashExecutor::RecordingTrashExecutor(const RecordingTrashExecutionGate& gate)
+  : gate(gate)
+{
+}
+
+RecordingTrashExecutorResult RecordingTrashExecutor::executeNormalCase(
+  const std::string& recordingFile,
+  const RecordingMutationRevision& expectedRevision,
+  const RecordingMutationPolicy& policy) const
+{
+  RecordingTrashExecutorResult result;
+  result.recordingFile = recordingFile;
+  result.gate = gate.validate(recordingFile, expectedRevision, policy);
+
+  if (result.gate.status == RecordingTrashExecutionGateStatus::Conflict) {
+    result.status = RecordingTrashExecutorStatus::Conflict;
+    result.message = "Recording state changed after preview.";
+    return result;
+  }
+
+  if (result.gate.status != RecordingTrashExecutionGateStatus::Ready) {
+    result.status = RecordingTrashExecutorStatus::Blocked;
+    result.message = "Recording trash execution is blocked by the current state or policy.";
+    return result;
+  }
+
+  const std::string targetFile = deletedFileName(recordingFile);
+  if (targetFile.empty()) {
+    result.status = RecordingTrashExecutorStatus::Blocked;
+    result.message = "Only active .rec recordings can be moved to the VDR trash.";
+    return result;
+  }
+
+  LOCK_TIMERS_WRITE;
+  LOCK_RECORDINGS_WRITE;
+
+  cRecording* recording = Recordings->GetByName(recordingFile.c_str());
+  if (!recording) {
+    result.status = RecordingTrashExecutorStatus::NotFound;
+    result.message = "Recording disappeared before execution.";
+    return result;
+  }
+
+  const char* nowReplaying = cReplayControl::NowReplaying();
+  if (nowReplaying && std::strcmp(nowReplaying, recordingFile.c_str()) == 0) {
+    result.status = RecordingTrashExecutorStatus::Conflict;
+    result.message = "Recording started replaying after validation.";
+    return result;
+  }
+
+  if (RecordingsHandler.GetUsage(recordingFile.c_str()) != ruNone) {
+    result.status = RecordingTrashExecutorStatus::Conflict;
+    result.message = "Recording handler usage changed after validation.";
+    return result;
+  }
+
+  if (cRecordControls::GetRecordControl(recordingFile.c_str()) != nullptr) {
+    result.status = RecordingTrashExecutorStatus::Conflict;
+    result.message = "A local recording control became active after validation.";
+    return result;
+  }
+
+  const cString timerIdText = GetRecordingTimerId(recordingFile.c_str());
+  const char* timerId = *timerIdText;
+  if (timerId && *timerId) {
+    result.status = RecordingTrashExecutorStatus::Conflict;
+    result.message = "A timer association appeared after validation.";
+    return result;
+  }
+
+  if (!recording->Delete()) {
+    result.status = RecordingTrashExecutorStatus::Failed;
+    result.message = "VDR failed to rename the recording into its deleted state.";
+    return result;
+  }
+
+  {
+    LOCK_DELETEDRECORDINGS_WRITE;
+    Recordings->Del(recording, false);
+    DeletedRecordings->Add(recording);
+  }
+
+  cVideoDiskUsage::ForceCheck();
+  StateChangeTracker::UpdateRecordings();
+
+  result.status = RecordingTrashExecutorStatus::Trashed;
+  result.deletedRecordingFile = targetFile;
+  result.message = "Recording moved to the VDR trash.";
+  return result;
+}
+
+const char* RecordingTrashExecutorStatusName(RecordingTrashExecutorStatus status)
+{
+  switch (status) {
+    case RecordingTrashExecutorStatus::Trashed:
+      return "trashed";
+    case RecordingTrashExecutorStatus::Conflict:
+      return "conflict";
+    case RecordingTrashExecutorStatus::Blocked:
+      return "blocked";
+    case RecordingTrashExecutorStatus::NotFound:
+      return "not-found";
+    case RecordingTrashExecutorStatus::Failed:
+      return "failed";
+  }
+
+  return "failed";
+}

--- a/recordingtrashexecutor.cpp
+++ b/recordingtrashexecutor.cpp
@@ -3,6 +3,7 @@
 #include "changestatetracker.h"
 
 #include <cstring>
+#include <unistd.h>
 
 #include <vdr/menu.h>
 #include <vdr/recording.h>
@@ -23,6 +24,11 @@ std::string deletedFileName(const std::string& recordingFile)
   return std::string();
 }
 
+bool pathExists(const std::string& path)
+{
+  return !path.empty() && access(path.c_str(), F_OK) == 0;
+}
+
 }
 
 RecordingTrashExecutor::RecordingTrashExecutor(const RecordingTrashExecutionGate& gate)
@@ -37,6 +43,22 @@ RecordingTrashExecutorResult RecordingTrashExecutor::executeNormalCase(
 {
   RecordingTrashExecutorResult result;
   result.recordingFile = recordingFile;
+
+  const std::string targetFile = deletedFileName(recordingFile);
+  if (targetFile.empty()) {
+    result.status = RecordingTrashExecutorStatus::Blocked;
+    result.message = "Only active .rec recordings can be moved to the VDR trash.";
+    return result;
+  }
+
+  result.deletedRecordingFile = targetFile;
+
+  if (!pathExists(recordingFile) && pathExists(targetFile)) {
+    result.status = RecordingTrashExecutorStatus::AlreadyTrashed;
+    result.message = "Recording is already present in the VDR trash.";
+    return result;
+  }
+
   result.gate = gate.validate(recordingFile, expectedRevision, policy);
 
   if (result.gate.status == RecordingTrashExecutionGateStatus::Conflict) {
@@ -51,20 +73,25 @@ RecordingTrashExecutorResult RecordingTrashExecutor::executeNormalCase(
     return result;
   }
 
-  const std::string targetFile = deletedFileName(recordingFile);
-  if (targetFile.empty()) {
-    result.status = RecordingTrashExecutorStatus::Blocked;
-    result.message = "Only active .rec recordings can be moved to the VDR trash.";
-    return result;
-  }
-
   LOCK_TIMERS_WRITE;
   LOCK_RECORDINGS_WRITE;
 
   cRecording* recording = Recordings->GetByName(recordingFile.c_str());
   if (!recording) {
-    result.status = RecordingTrashExecutorStatus::NotFound;
-    result.message = "Recording disappeared before execution.";
+    if (!pathExists(recordingFile) && pathExists(targetFile)) {
+      result.status = RecordingTrashExecutorStatus::AlreadyTrashed;
+      result.message = "Recording is already present in the VDR trash.";
+    }
+    else {
+      result.status = RecordingTrashExecutorStatus::NotFound;
+      result.message = "Recording disappeared before execution.";
+    }
+    return result;
+  }
+
+  if (pathExists(targetFile)) {
+    result.status = RecordingTrashExecutorStatus::Conflict;
+    result.message = "The VDR trash target already exists.";
     return result;
   }
 
@@ -101,6 +128,12 @@ RecordingTrashExecutorResult RecordingTrashExecutor::executeNormalCase(
     return result;
   }
 
+  if (pathExists(recordingFile) || !pathExists(targetFile)) {
+    result.status = RecordingTrashExecutorStatus::Failed;
+    result.message = "Recording trash postcondition verification failed.";
+    return result;
+  }
+
   {
     LOCK_DELETEDRECORDINGS_WRITE;
     Recordings->Del(recording, false);
@@ -111,7 +144,6 @@ RecordingTrashExecutorResult RecordingTrashExecutor::executeNormalCase(
   StateChangeTracker::UpdateRecordings();
 
   result.status = RecordingTrashExecutorStatus::Trashed;
-  result.deletedRecordingFile = targetFile;
   result.message = "Recording moved to the VDR trash.";
   return result;
 }
@@ -121,6 +153,8 @@ const char* RecordingTrashExecutorStatusName(RecordingTrashExecutorStatus status
   switch (status) {
     case RecordingTrashExecutorStatus::Trashed:
       return "trashed";
+    case RecordingTrashExecutorStatus::AlreadyTrashed:
+      return "already-trashed";
     case RecordingTrashExecutorStatus::Conflict:
       return "conflict";
     case RecordingTrashExecutorStatus::Blocked:

--- a/recordingtrashexecutor.cpp
+++ b/recordingtrashexecutor.cpp
@@ -6,6 +6,7 @@
 
 #include <vdr/menu.h>
 #include <vdr/recording.h>
+#include <vdr/videodir.h>
 
 namespace {
 

--- a/recordingtrashexecutor.h
+++ b/recordingtrashexecutor.h
@@ -1,0 +1,42 @@
+#ifndef __RECORDINGTRASHEXECUTOR_H
+#define __RECORDINGTRASHEXECUTOR_H
+
+#include "recordingexecution.h"
+
+#include <string>
+
+enum class RecordingTrashExecutorStatus
+{
+  Trashed,
+  Conflict,
+  Blocked,
+  NotFound,
+  Failed
+};
+
+struct RecordingTrashExecutorResult
+{
+  RecordingTrashExecutorStatus status = RecordingTrashExecutorStatus::Failed;
+  std::string recordingFile;
+  std::string deletedRecordingFile;
+  std::string message;
+  RecordingTrashExecutionGateResult gate;
+};
+
+class RecordingTrashExecutor
+{
+public:
+  explicit RecordingTrashExecutor(const RecordingTrashExecutionGate& gate);
+
+  RecordingTrashExecutorResult executeNormalCase(
+    const std::string& recordingFile,
+    const RecordingMutationRevision& expectedRevision,
+    const RecordingMutationPolicy& policy) const;
+
+private:
+  const RecordingTrashExecutionGate& gate;
+};
+
+const char* RecordingTrashExecutorStatusName(RecordingTrashExecutorStatus status);
+
+#endif

--- a/recordingtrashexecutor.h
+++ b/recordingtrashexecutor.h
@@ -8,6 +8,7 @@
 enum class RecordingTrashExecutorStatus
 {
   Trashed,
+  AlreadyTrashed,
   Conflict,
   Blocked,
   NotFound,

--- a/recordingvalidate.cpp
+++ b/recordingvalidate.cpp
@@ -1,0 +1,139 @@
+#include "recordingvalidate.h"
+
+#include "recordinganalysis.h"
+#include "recordingexecution.h"
+#include "recordingmutation.h"
+#include "tools.h"
+
+#include <cxxtools/jsonserializer.h>
+
+#include <string>
+
+namespace {
+
+bool parseLongLong(const std::string& value, long long& result)
+{
+  if (value.empty())
+    return false;
+
+  try {
+    std::size_t parsed = 0;
+    result = std::stoll(value, &parsed, 10);
+    return parsed == value.size();
+  }
+  catch (...) {
+    return false;
+  }
+}
+
+std::vector<std::string> constraintNames(
+  const std::vector<RecordingConstraint>& constraints)
+{
+  std::vector<std::string> names;
+  for (RecordingConstraint constraint : constraints)
+    names.push_back(RecordingConstraintName(constraint));
+  return names;
+}
+
+}
+
+void RecordingTrashValidateResponder::reply(
+  std::ostream& out,
+  cxxtools::http::Request& request,
+  cxxtools::http::Reply& reply)
+{
+  QueryHandler::addHeader(reply);
+
+  if (request.method() == "OPTIONS") {
+    reply.addHeader("Allow", "POST");
+    reply.httpReturn(200, "OK");
+    return;
+  }
+
+  if (request.method() != "POST") {
+    reply.httpReturn(501, "Only POST method is supported by the /recordings/trash/validate service.");
+    return;
+  }
+
+  QueryHandler query("/recordings/trash/validate", request);
+  const std::string recordingFile = query.getBodyAsString("file");
+  const std::string recordingsStateText =
+    query.getBodyAsString("revision_recordings_state");
+  const std::string timersStateText =
+    query.getBodyAsString("revision_timers_state");
+
+  long long recordingsState = 0;
+  long long timersState = 0;
+
+  if (recordingFile.empty()) {
+    reply.httpReturn(400, "Recording file is missing.");
+    return;
+  }
+
+  if (!parseLongLong(recordingsStateText, recordingsState) ||
+      !parseLongLong(timersStateText, timersState)) {
+    reply.httpReturn(400, "Recording revision is missing or invalid.");
+    return;
+  }
+
+  RecordingMutationPolicy policy;
+  policy.allowRecordingHandlerStop = query.getBodyAsBool("allow_recording_handler_stop");
+  policy.allowReplayStop = query.getBodyAsBool("allow_replay_stop");
+  policy.allowLocalTimerStop = query.getBodyAsBool("allow_local_timer_stop");
+  policy.allowRemoteTimerStop = query.getBodyAsBool("allow_remote_timer_stop");
+
+  VdrRecordingLookup recordingLookup;
+  VdrRecordingReplayLookup replayLookup;
+  VdrRecordingHandlerLookup recordingHandlerLookup;
+  VdrRecordingLocalTimerLookup localTimerLookup;
+  VdrRecordingRemoteTimerLookup remoteTimerLookup;
+  VdrRecordingSearchTimerLookup searchTimerLookup;
+
+  RecordingTrashAnalyzer analyzer(
+    recordingLookup,
+    replayLookup,
+    recordingHandlerLookup,
+    localTimerLookup,
+    remoteTimerLookup,
+    searchTimerLookup);
+
+  RecordingMutationPlanner planner;
+  RecordingTrashExecutionGate gate(analyzer, planner);
+
+  RecordingMutationRevision expectedRevision;
+  expectedRevision.recordingFile = recordingFile;
+  expectedRevision.recordingsState = recordingsState;
+  expectedRevision.timersState = timersState;
+
+  const RecordingTrashExecutionGateResult result =
+    gate.validate(recordingFile, expectedRevision, policy);
+
+  reply.addHeader("Content-Type", "application/json; charset=utf-8");
+
+  cxxtools::JsonSerializer serializer(out);
+  serializer.serialize(
+    std::string(RecordingTrashExecutionGateStatusName(result.status)),
+    "status");
+  serializer.serialize(result.recordingFile, "recording_file");
+  serializer.serialize(constraintNames(result.blockers), "blockers");
+  serializer.serialize(result.warnings, "warnings");
+  serializer.serialize(
+    result.expectedRevision.recordingFile,
+    "expected_revision_recording_file");
+  serializer.serialize(
+    result.expectedRevision.recordingsState,
+    "expected_revision_recordings_state");
+  serializer.serialize(
+    result.expectedRevision.timersState,
+    "expected_revision_timers_state");
+  serializer.serialize(
+    result.currentRevision.recordingFile,
+    "current_revision_recording_file");
+  serializer.serialize(
+    result.currentRevision.recordingsState,
+    "current_revision_recordings_state");
+  serializer.serialize(
+    result.currentRevision.timersState,
+    "current_revision_timers_state");
+  serializer.finish();
+}

--- a/recordingvalidate.h
+++ b/recordingvalidate.h
@@ -1,0 +1,25 @@
+#ifndef __RECORDINGVALIDATE_H
+#define __RECORDINGVALIDATE_H
+
+#include <cxxtools/http/request.h>
+#include <cxxtools/http/reply.h>
+#include <cxxtools/http/responder.h>
+
+class RecordingTrashValidateResponder : public cxxtools::http::Responder
+{
+public:
+  explicit RecordingTrashValidateResponder(cxxtools::http::Service& service)
+    : cxxtools::http::Responder(service)
+  {
+  }
+
+  void reply(
+    std::ostream& out,
+    cxxtools::http::Request& request,
+    cxxtools::http::Reply& reply) override;
+};
+
+typedef cxxtools::http::CachedService<RecordingTrashValidateResponder>
+  RecordingTrashValidateService;
+
+#endif

--- a/serverthread.cpp
+++ b/serverthread.cpp
@@ -42,6 +42,7 @@ void cServerThread::Action(void)
   RecordingsService recordingsService;
   RecordingMovePreviewService recordingMovePreviewService;
   RecordingMoveValidateService recordingMoveValidateService;
+  RecordingMoveService recordingMoveService;
   RecordingTrashPreviewService recordingTrashPreviewService;
   RecordingTrashValidateService recordingTrashValidateService;
   RecordingTrashService recordingTrashService;
@@ -66,6 +67,7 @@ void cServerThread::Action(void)
   RestfulService* recordingsMarks = new RestfulService("/recordings/marks", true, 1, recordings);
   RestfulService* recordingMovePreview = new RestfulService("/recordings/move/preview", true, 1, recordings);
   RestfulService* recordingMoveValidate = new RestfulService("/recordings/move/validate", true, 1, recordings);
+  RestfulService* recordingMove = new RestfulService("/recordings/move", true, 1, recordings);
   RestfulService* recordingTrashPreview = new RestfulService("/recordings/trash/preview", true, 1, recordings);
   RestfulService* recordingTrashValidate = new RestfulService("/recordings/trash/validate", true, 1, recordings);
   RestfulService* recordingTrash = new RestfulService("/recordings/trash", true, 1, recordings);
@@ -91,6 +93,7 @@ void cServerThread::Action(void)
   services->appendService(recordingsMarks);
   services->appendService(recordingMovePreview);
   services->appendService(recordingMoveValidate);
+  services->appendService(recordingMove);
   services->appendService(recordingTrashPreview);
   services->appendService(recordingTrashValidate);
   services->appendService(recordingTrash);
@@ -109,6 +112,7 @@ void cServerThread::Action(void)
   server->addService(std::move(*events->Regex()), eventsService);
   server->addService(std::move(*recordingMovePreview->Regex()), recordingMovePreviewService);
   server->addService(std::move(*recordingMoveValidate->Regex()), recordingMoveValidateService);
+  server->addService(std::move(*recordingMove->Regex()), recordingMoveService);
   server->addService(std::move(*recordingTrashPreview->Regex()), recordingTrashPreviewService);
   server->addService(std::move(*recordingTrashValidate->Regex()), recordingTrashValidateService);
   server->addService(std::move(*recordingTrash->Regex()), recordingTrashService);

--- a/serverthread.cpp
+++ b/serverthread.cpp
@@ -41,6 +41,7 @@ void cServerThread::Action(void)
   EventsService eventsService;
   RecordingsService recordingsService;
   RecordingTrashPreviewService recordingTrashPreviewService;
+  RecordingTrashValidateService recordingTrashValidateService;
   RemoteService remoteService;
   TimersService timersService;
   ChangeStateService changeStateService;
@@ -61,6 +62,7 @@ void cServerThread::Action(void)
   RestfulService* recordingsCut = new RestfulService("/recordings/cut", true, 1, recordings);
   RestfulService* recordingsMarks = new RestfulService("/recordings/marks", true, 1, recordings);
   RestfulService* recordingTrashPreview = new RestfulService("/recordings/trash/preview", true, 1, recordings);
+  RestfulService* recordingTrashValidate = new RestfulService("/recordings/trash/validate", true, 1, recordings);
   RestfulService* remote = new RestfulService("/remote", true, 1);
   RestfulService* timers = new RestfulService("/timers", true, 1);
   RestfulService* changeState = new RestfulService("/change-state", true, 1);
@@ -82,6 +84,7 @@ void cServerThread::Action(void)
   services->appendService(recordingsCut);
   services->appendService(recordingsMarks);
   services->appendService(recordingTrashPreview);
+  services->appendService(recordingTrashValidate);
   services->appendService(remote);
   services->appendService(timers);
   services->appendService(changeState);
@@ -96,6 +99,7 @@ void cServerThread::Action(void)
   server->addService(std::move(*channels->Regex()), channelsService);
   server->addService(std::move(*events->Regex()), eventsService);
   server->addService(std::move(*recordingTrashPreview->Regex()), recordingTrashPreviewService);
+  server->addService(std::move(*recordingTrashValidate->Regex()), recordingTrashValidateService);
   server->addService(std::move(*recordings->Regex()), recordingsService);
   server->addService(std::move(*remote->Regex()), remoteService);
   server->addService(std::move(*timers->Regex()), timersService);

--- a/serverthread.cpp
+++ b/serverthread.cpp
@@ -40,6 +40,7 @@ void cServerThread::Action(void)
   ChannelsService channelsService;
   EventsService eventsService;
   RecordingsService recordingsService;
+  RecordingMovePreviewService recordingMovePreviewService;
   RecordingTrashPreviewService recordingTrashPreviewService;
   RecordingTrashValidateService recordingTrashValidateService;
   RecordingTrashService recordingTrashService;
@@ -62,6 +63,7 @@ void cServerThread::Action(void)
   RestfulService* recordings = new RestfulService("/recordings", true, 1);
   RestfulService* recordingsCut = new RestfulService("/recordings/cut", true, 1, recordings);
   RestfulService* recordingsMarks = new RestfulService("/recordings/marks", true, 1, recordings);
+  RestfulService* recordingMovePreview = new RestfulService("/recordings/move/preview", true, 1, recordings);
   RestfulService* recordingTrashPreview = new RestfulService("/recordings/trash/preview", true, 1, recordings);
   RestfulService* recordingTrashValidate = new RestfulService("/recordings/trash/validate", true, 1, recordings);
   RestfulService* recordingTrash = new RestfulService("/recordings/trash", true, 1, recordings);
@@ -85,6 +87,7 @@ void cServerThread::Action(void)
   services->appendService(recordings);
   services->appendService(recordingsCut);
   services->appendService(recordingsMarks);
+  services->appendService(recordingMovePreview);
   services->appendService(recordingTrashPreview);
   services->appendService(recordingTrashValidate);
   services->appendService(recordingTrash);
@@ -101,6 +104,7 @@ void cServerThread::Action(void)
   server->addService(std::move(*info->Regex()), infoService);
   server->addService(std::move(*channels->Regex()), channelsService);
   server->addService(std::move(*events->Regex()), eventsService);
+  server->addService(std::move(*recordingMovePreview->Regex()), recordingMovePreviewService);
   server->addService(std::move(*recordingTrashPreview->Regex()), recordingTrashPreviewService);
   server->addService(std::move(*recordingTrashValidate->Regex()), recordingTrashValidateService);
   server->addService(std::move(*recordingTrash->Regex()), recordingTrashService);
@@ -147,7 +151,6 @@ void cServerThread::addWebappService(string name) {
       }
       i++;
   }
-
   if (false == occupied) {
       RestfulService* service = new RestfulService(path, true, 1);
       services->appendService(service);

--- a/serverthread.cpp
+++ b/serverthread.cpp
@@ -40,6 +40,7 @@ void cServerThread::Action(void)
   ChannelsService channelsService;
   EventsService eventsService;
   RecordingsService recordingsService;
+  RecordingTrashPreviewService recordingTrashPreviewService;
   RemoteService remoteService;
   TimersService timersService;
   ChangeStateService changeStateService;
@@ -59,6 +60,7 @@ void cServerThread::Action(void)
   RestfulService* recordings = new RestfulService("/recordings", true, 1);
   RestfulService* recordingsCut = new RestfulService("/recordings/cut", true, 1, recordings);
   RestfulService* recordingsMarks = new RestfulService("/recordings/marks", true, 1, recordings);
+  RestfulService* recordingTrashPreview = new RestfulService("/recordings/trash/preview", true, 1, recordings);
   RestfulService* remote = new RestfulService("/remote", true, 1);
   RestfulService* timers = new RestfulService("/timers", true, 1);
   RestfulService* changeState = new RestfulService("/change-state", true, 1);
@@ -79,6 +81,7 @@ void cServerThread::Action(void)
   services->appendService(recordings);
   services->appendService(recordingsCut);
   services->appendService(recordingsMarks);
+  services->appendService(recordingTrashPreview);
   services->appendService(remote);
   services->appendService(timers);
   services->appendService(changeState);
@@ -92,6 +95,7 @@ void cServerThread::Action(void)
   server->addService(std::move(*info->Regex()), infoService);
   server->addService(std::move(*channels->Regex()), channelsService);
   server->addService(std::move(*events->Regex()), eventsService);
+  server->addService(std::move(*recordingTrashPreview->Regex()), recordingTrashPreviewService);
   server->addService(std::move(*recordings->Regex()), recordingsService);
   server->addService(std::move(*remote->Regex()), remoteService);
   server->addService(std::move(*timers->Regex()), timersService);

--- a/serverthread.cpp
+++ b/serverthread.cpp
@@ -42,6 +42,7 @@ void cServerThread::Action(void)
   RecordingsService recordingsService;
   RecordingTrashPreviewService recordingTrashPreviewService;
   RecordingTrashValidateService recordingTrashValidateService;
+  RecordingTrashService recordingTrashService;
   RemoteService remoteService;
   TimersService timersService;
   ChangeStateService changeStateService;
@@ -63,6 +64,7 @@ void cServerThread::Action(void)
   RestfulService* recordingsMarks = new RestfulService("/recordings/marks", true, 1, recordings);
   RestfulService* recordingTrashPreview = new RestfulService("/recordings/trash/preview", true, 1, recordings);
   RestfulService* recordingTrashValidate = new RestfulService("/recordings/trash/validate", true, 1, recordings);
+  RestfulService* recordingTrash = new RestfulService("/recordings/trash", true, 1, recordings);
   RestfulService* remote = new RestfulService("/remote", true, 1);
   RestfulService* timers = new RestfulService("/timers", true, 1);
   RestfulService* changeState = new RestfulService("/change-state", true, 1);
@@ -85,6 +87,7 @@ void cServerThread::Action(void)
   services->appendService(recordingsMarks);
   services->appendService(recordingTrashPreview);
   services->appendService(recordingTrashValidate);
+  services->appendService(recordingTrash);
   services->appendService(remote);
   services->appendService(timers);
   services->appendService(changeState);
@@ -100,6 +103,7 @@ void cServerThread::Action(void)
   server->addService(std::move(*events->Regex()), eventsService);
   server->addService(std::move(*recordingTrashPreview->Regex()), recordingTrashPreviewService);
   server->addService(std::move(*recordingTrashValidate->Regex()), recordingTrashValidateService);
+  server->addService(std::move(*recordingTrash->Regex()), recordingTrashService);
   server->addService(std::move(*recordings->Regex()), recordingsService);
   server->addService(std::move(*remote->Regex()), remoteService);
   server->addService(std::move(*timers->Regex()), timersService);

--- a/serverthread.cpp
+++ b/serverthread.cpp
@@ -41,6 +41,7 @@ void cServerThread::Action(void)
   EventsService eventsService;
   RecordingsService recordingsService;
   RecordingMovePreviewService recordingMovePreviewService;
+  RecordingMoveValidateService recordingMoveValidateService;
   RecordingTrashPreviewService recordingTrashPreviewService;
   RecordingTrashValidateService recordingTrashValidateService;
   RecordingTrashService recordingTrashService;
@@ -64,6 +65,7 @@ void cServerThread::Action(void)
   RestfulService* recordingsCut = new RestfulService("/recordings/cut", true, 1, recordings);
   RestfulService* recordingsMarks = new RestfulService("/recordings/marks", true, 1, recordings);
   RestfulService* recordingMovePreview = new RestfulService("/recordings/move/preview", true, 1, recordings);
+  RestfulService* recordingMoveValidate = new RestfulService("/recordings/move/validate", true, 1, recordings);
   RestfulService* recordingTrashPreview = new RestfulService("/recordings/trash/preview", true, 1, recordings);
   RestfulService* recordingTrashValidate = new RestfulService("/recordings/trash/validate", true, 1, recordings);
   RestfulService* recordingTrash = new RestfulService("/recordings/trash", true, 1, recordings);
@@ -88,6 +90,7 @@ void cServerThread::Action(void)
   services->appendService(recordingsCut);
   services->appendService(recordingsMarks);
   services->appendService(recordingMovePreview);
+  services->appendService(recordingMoveValidate);
   services->appendService(recordingTrashPreview);
   services->appendService(recordingTrashValidate);
   services->appendService(recordingTrash);
@@ -105,6 +108,7 @@ void cServerThread::Action(void)
   server->addService(std::move(*channels->Regex()), channelsService);
   server->addService(std::move(*events->Regex()), eventsService);
   server->addService(std::move(*recordingMovePreview->Regex()), recordingMovePreviewService);
+  server->addService(std::move(*recordingMoveValidate->Regex()), recordingMoveValidateService);
   server->addService(std::move(*recordingTrashPreview->Regex()), recordingTrashPreviewService);
   server->addService(std::move(*recordingTrashValidate->Regex()), recordingTrashValidateService);
   server->addService(std::move(*recordingTrash->Regex()), recordingTrashService);

--- a/serverthread.h
+++ b/serverthread.h
@@ -17,6 +17,7 @@
 #include "events.h"
 #include "recordings.h"
 #include "recordingpreview.h"
+#include "recordingmovepreview.h"
 #include "recordingvalidate.h"
 #include "recordingtrash.h"
 #include "remote.h"

--- a/serverthread.h
+++ b/serverthread.h
@@ -19,6 +19,7 @@
 #include "recordingpreview.h"
 #include "recordingmovepreview.h"
 #include "recordingvalidate.h"
+#include "recordingmovevalidate.h"
 #include "recordingtrash.h"
 #include "remote.h"
 #include "timers.h"

--- a/serverthread.h
+++ b/serverthread.h
@@ -18,6 +18,7 @@
 #include "recordings.h"
 #include "recordingpreview.h"
 #include "recordingvalidate.h"
+#include "recordingtrash.h"
 #include "remote.h"
 #include "timers.h"
 #include "changestate.h"

--- a/serverthread.h
+++ b/serverthread.h
@@ -17,6 +17,7 @@
 #include "events.h"
 #include "recordings.h"
 #include "recordingpreview.h"
+#include "recordingvalidate.h"
 #include "remote.h"
 #include "timers.h"
 #include "changestate.h"

--- a/serverthread.h
+++ b/serverthread.h
@@ -16,6 +16,7 @@
 #include "channels.h"
 #include "events.h"
 #include "recordings.h"
+#include "recordingpreview.h"
 #include "remote.h"
 #include "timers.h"
 #include "changestate.h"

--- a/serverthread.h
+++ b/serverthread.h
@@ -20,6 +20,7 @@
 #include "recordingmovepreview.h"
 #include "recordingvalidate.h"
 #include "recordingmovevalidate.h"
+#include "recordingmove.h"
 #include "recordingtrash.h"
 #include "remote.h"
 #include "timers.h"

--- a/tests/test_recording_move_analysis.cpp
+++ b/tests/test_recording_move_analysis.cpp
@@ -134,13 +134,6 @@ int main()
   assert(!sameTarget.hasConstraint(RecordingConstraint::MoveTargetExists));
 
   recordingLookup.results[target] = {true, target};
-  analyzer = makeAnalyzer(
-    recordingLookup,
-    replayLookup,
-    handlerLookup,
-    localTimerLookup,
-    remoteTimerLookup,
-    searchTimerLookup);
   const RecordingMutationAnalysis collision = analyzer.analyze(source, target);
   assert(collision.hasConstraint(RecordingConstraint::MoveTargetExists));
   assert(collision.revision.recordingsState != ready.revision.recordingsState);
@@ -150,13 +143,6 @@ int main()
   localTimerLookup.result.active = true;
   remoteTimerLookup.result.active = true;
   searchTimerLookup.result.searchTimerRecording = true;
-  analyzer = makeAnalyzer(
-    recordingLookup,
-    replayLookup,
-    handlerLookup,
-    localTimerLookup,
-    remoteTimerLookup,
-    searchTimerLookup);
   const RecordingMutationAnalysis active = analyzer.analyze(source, "/srv/vdr/video/Other/2026.rec");
   assert(active.hasConstraint(RecordingConstraint::ReplayActive));
   assert(active.hasConstraint(RecordingConstraint::RecordingHandlerBusy));

--- a/tests/test_recording_move_analysis.cpp
+++ b/tests/test_recording_move_analysis.cpp
@@ -1,0 +1,173 @@
+#include "../recordinganalysis.h"
+
+#include <cassert>
+#include <map>
+#include <string>
+
+namespace {
+
+class FakeRecordingLookup : public IRecordingLookup
+{
+public:
+  std::map<std::string, RecordingLookupResult> results;
+
+  RecordingLookupResult find(const std::string& recordingFile) const override
+  {
+    const auto result = results.find(recordingFile);
+    return result == results.end() ? RecordingLookupResult() : result->second;
+  }
+};
+
+class FakeReplayLookup : public IRecordingReplayLookup
+{
+public:
+  bool replaying = false;
+
+  bool isReplaying(const std::string&) const override
+  {
+    return replaying;
+  }
+};
+
+class FakeHandlerLookup : public IRecordingHandlerLookup
+{
+public:
+  RecordingHandlerLookupResult result{true, false};
+
+  RecordingHandlerLookupResult getUsage(const std::string&) const override
+  {
+    return result;
+  }
+};
+
+class FakeLocalTimerLookup : public IRecordingLocalTimerLookup
+{
+public:
+  RecordingLocalTimerLookupResult result{true, false};
+
+  RecordingLocalTimerLookupResult findActive(const std::string&) const override
+  {
+    return result;
+  }
+};
+
+class FakeRemoteTimerLookup : public IRecordingRemoteTimerLookup
+{
+public:
+  RecordingRemoteTimerLookupResult result{true, false, 0, ""};
+
+  RecordingRemoteTimerLookupResult findActive(const std::string&) const override
+  {
+    return result;
+  }
+};
+
+class FakeSearchTimerLookup : public IRecordingSearchTimerLookup
+{
+public:
+  RecordingSearchTimerLookupResult result{true, false, -1};
+
+  RecordingSearchTimerLookupResult findOrigin(const std::string&) const override
+  {
+    return result;
+  }
+};
+
+RecordingMoveAnalyzer makeAnalyzer(
+  const FakeRecordingLookup& recordingLookup,
+  const FakeReplayLookup& replayLookup,
+  const FakeHandlerLookup& handlerLookup,
+  const FakeLocalTimerLookup& localTimerLookup,
+  const FakeRemoteTimerLookup& remoteTimerLookup,
+  const FakeSearchTimerLookup& searchTimerLookup)
+{
+  return RecordingMoveAnalyzer(
+    recordingLookup,
+    replayLookup,
+    handlerLookup,
+    localTimerLookup,
+    remoteTimerLookup,
+    searchTimerLookup);
+}
+
+}
+
+int main()
+{
+  const std::string source = "/srv/vdr/video/Source/2026-07-14.20.00.1-0.rec";
+  const std::string target = "/srv/vdr/video/Target/2026-07-14.20.00.1-0.rec";
+
+  FakeRecordingLookup recordingLookup;
+  recordingLookup.results[source] = {true, source};
+  FakeReplayLookup replayLookup;
+  FakeHandlerLookup handlerLookup;
+  FakeLocalTimerLookup localTimerLookup;
+  FakeRemoteTimerLookup remoteTimerLookup;
+  FakeSearchTimerLookup searchTimerLookup;
+
+  RecordingMoveAnalyzer analyzer = makeAnalyzer(
+    recordingLookup,
+    replayLookup,
+    handlerLookup,
+    localTimerLookup,
+    remoteTimerLookup,
+    searchTimerLookup);
+
+  const RecordingMutationAnalysis ready = analyzer.analyze(source, target);
+  assert(ready.type == RecordingMutationType::Move);
+  assert(ready.recordingFile == source);
+  assert(ready.targetFile == target);
+  assert(ready.revision.recordingFile == source);
+  assert(ready.revision.targetFile == target);
+  assert(ready.revision.recordingsState != 0);
+  assert(ready.revision.timersState != 0);
+  assert(ready.constraints.empty());
+
+  const RecordingMutationAnalysis missingTarget = analyzer.analyze(source, "");
+  assert(missingTarget.hasConstraint(RecordingConstraint::MoveTargetMissing));
+
+  const RecordingMutationAnalysis invalidTarget = analyzer.analyze(source, "Target/relative.rec");
+  assert(invalidTarget.hasConstraint(RecordingConstraint::MoveTargetInvalid));
+
+  const RecordingMutationAnalysis sameTarget = analyzer.analyze(source, source);
+  assert(sameTarget.hasConstraint(RecordingConstraint::MoveTargetSameAsSource));
+  assert(!sameTarget.hasConstraint(RecordingConstraint::MoveTargetExists));
+
+  recordingLookup.results[target] = {true, target};
+  analyzer = makeAnalyzer(
+    recordingLookup,
+    replayLookup,
+    handlerLookup,
+    localTimerLookup,
+    remoteTimerLookup,
+    searchTimerLookup);
+  const RecordingMutationAnalysis collision = analyzer.analyze(source, target);
+  assert(collision.hasConstraint(RecordingConstraint::MoveTargetExists));
+  assert(collision.revision.recordingsState != ready.revision.recordingsState);
+
+  replayLookup.replaying = true;
+  handlerLookup.result.busy = true;
+  localTimerLookup.result.active = true;
+  remoteTimerLookup.result.active = true;
+  searchTimerLookup.result.searchTimerRecording = true;
+  analyzer = makeAnalyzer(
+    recordingLookup,
+    replayLookup,
+    handlerLookup,
+    localTimerLookup,
+    remoteTimerLookup,
+    searchTimerLookup);
+  const RecordingMutationAnalysis active = analyzer.analyze(source, "/srv/vdr/video/Other/2026.rec");
+  assert(active.hasConstraint(RecordingConstraint::ReplayActive));
+  assert(active.hasConstraint(RecordingConstraint::RecordingHandlerBusy));
+  assert(active.hasConstraint(RecordingConstraint::LocalTimerActive));
+  assert(active.hasConstraint(RecordingConstraint::RemoteTimerActive));
+  assert(active.hasConstraint(RecordingConstraint::SearchTimerRecording));
+
+  const RecordingMutationAnalysis missingSource = analyzer.analyze(
+    "/srv/vdr/video/Missing/2026.rec",
+    target);
+  assert(missingSource.hasConstraint(RecordingConstraint::RecordingMissing));
+
+  return 0;
+}

--- a/tests/test_recording_move_execution_gate.cpp
+++ b/tests/test_recording_move_execution_gate.cpp
@@ -1,0 +1,140 @@
+#include "../recordingmoveexecution.h"
+
+#include <cassert>
+#include <map>
+#include <string>
+
+namespace {
+
+class FakeRecordingLookup : public IRecordingLookup
+{
+public:
+  std::map<std::string, RecordingLookupResult> results;
+
+  RecordingLookupResult find(const std::string& recordingFile) const override
+  {
+    const auto result = results.find(recordingFile);
+    return result == results.end() ? RecordingLookupResult() : result->second;
+  }
+};
+
+class FakeReplayLookup : public IRecordingReplayLookup
+{
+public:
+  bool replaying = false;
+
+  bool isReplaying(const std::string&) const override
+  {
+    return replaying;
+  }
+};
+
+class FakeHandlerLookup : public IRecordingHandlerLookup
+{
+public:
+  RecordingHandlerLookupResult result{true, false};
+
+  RecordingHandlerLookupResult getUsage(const std::string&) const override
+  {
+    return result;
+  }
+};
+
+class FakeLocalTimerLookup : public IRecordingLocalTimerLookup
+{
+public:
+  RecordingLocalTimerLookupResult result{true, false};
+
+  RecordingLocalTimerLookupResult findActive(const std::string&) const override
+  {
+    return result;
+  }
+};
+
+class FakeRemoteTimerLookup : public IRecordingRemoteTimerLookup
+{
+public:
+  RecordingRemoteTimerLookupResult result{true, false, 0, ""};
+
+  RecordingRemoteTimerLookupResult findActive(const std::string&) const override
+  {
+    return result;
+  }
+};
+
+class FakeSearchTimerLookup : public IRecordingSearchTimerLookup
+{
+public:
+  RecordingSearchTimerLookupResult result{true, false, -1};
+
+  RecordingSearchTimerLookupResult findOrigin(const std::string&) const override
+  {
+    return result;
+  }
+};
+
+}
+
+int main()
+{
+  const std::string source = "/srv/vdr/video/Source/2026-07-14.20.00.1-0.rec";
+  const std::string target = "/srv/vdr/video/Target/2026-07-14.20.00.1-0.rec";
+
+  FakeRecordingLookup recordingLookup;
+  recordingLookup.results[source] = {true, source};
+  FakeReplayLookup replayLookup;
+  FakeHandlerLookup handlerLookup;
+  FakeLocalTimerLookup localTimerLookup;
+  FakeRemoteTimerLookup remoteTimerLookup;
+  FakeSearchTimerLookup searchTimerLookup;
+
+  RecordingMoveAnalyzer analyzer(
+    recordingLookup,
+    replayLookup,
+    handlerLookup,
+    localTimerLookup,
+    remoteTimerLookup,
+    searchTimerLookup);
+  RecordingMutationPlanner planner;
+  RecordingMoveExecutionGate gate(analyzer, planner);
+  RecordingMutationPolicy policy;
+
+  const RecordingMutationAnalysis initial = analyzer.analyze(source, target);
+  const RecordingMoveExecutionGateResult ready = gate.validate(
+    source,
+    target,
+    initial.revision,
+    policy);
+  assert(ready.status == RecordingMoveExecutionGateStatus::Ready);
+  assert(ready.currentRevision.targetFile == target);
+
+  RecordingMutationRevision wrongTargetRevision = initial.revision;
+  wrongTargetRevision.targetFile = "/srv/vdr/video/Other/2026-07-14.20.00.1-0.rec";
+  const RecordingMoveExecutionGateResult wrongTarget = gate.validate(
+    source,
+    target,
+    wrongTargetRevision,
+    policy);
+  assert(wrongTarget.status == RecordingMoveExecutionGateStatus::Conflict);
+
+  recordingLookup.results[target] = {true, target};
+  const RecordingMoveExecutionGateResult collision = gate.validate(
+    source,
+    target,
+    initial.revision,
+    policy);
+  assert(collision.status == RecordingMoveExecutionGateStatus::Conflict);
+
+  recordingLookup.results.erase(target);
+  replayLookup.replaying = true;
+  const RecordingMutationAnalysis replayAnalysis = analyzer.analyze(source, target);
+  const RecordingMoveExecutionGateResult blocked = gate.validate(
+    source,
+    target,
+    replayAnalysis.revision,
+    policy);
+  assert(blocked.status == RecordingMoveExecutionGateStatus::Blocked);
+  assert(!blocked.blockers.empty());
+
+  return 0;
+}

--- a/tests/test_recording_move_plan.cpp
+++ b/tests/test_recording_move_plan.cpp
@@ -1,0 +1,121 @@
+#include "../recordingmutation.h"
+
+#include <cassert>
+
+namespace {
+
+RecordingMutationAnalysis baseMoveAnalysis()
+{
+  RecordingMutationAnalysis analysis;
+  analysis.type = RecordingMutationType::Move;
+  analysis.recordingFile = "/srv/vdr/video/Source/2026-07-14.20.15.1-0.rec";
+  analysis.targetFile = "/srv/vdr/video/Target/2026-07-14.20.15.1-0.rec";
+  analysis.revision.recordingFile = analysis.recordingFile;
+  analysis.revision.targetFile = analysis.targetFile;
+  analysis.revision.recordingsState = 100;
+  analysis.revision.timersState = 200;
+  return analysis;
+}
+
+bool hasBlocker(
+  const RecordingMutationPlan& plan,
+  RecordingConstraint constraint)
+{
+  for (const RecordingConstraint blocker : plan.blockers) {
+    if (blocker == constraint)
+      return true;
+  }
+  return false;
+}
+
+bool hasStep(
+  const RecordingMutationPlan& plan,
+  RecordingMutationStep step)
+{
+  for (const RecordingMutationStep candidate : plan.steps) {
+    if (candidate == step)
+      return true;
+  }
+  return false;
+}
+
+}
+
+int main()
+{
+  RecordingMutationPlanner planner;
+  RecordingMutationPolicy policy;
+
+  const RecordingMutationPlan ready =
+    planner.buildMovePlan(baseMoveAnalysis(), policy);
+
+  assert(ready.executable);
+  assert(ready.blockers.empty());
+  assert(hasStep(ready, RecordingMutationStep::MoveRecording));
+  assert(hasStep(ready, RecordingMutationStep::RefreshRecordings));
+  assert(hasStep(ready, RecordingMutationStep::NotifyChange));
+  assert(ready.expectedRevision.recordingsState == 100);
+  assert(ready.expectedRevision.timersState == 200);
+  assert(
+    ready.expectedRevision.targetFile ==
+    "/srv/vdr/video/Target/2026-07-14.20.15.1-0.rec");
+
+  RecordingMutationAnalysis missingTarget = baseMoveAnalysis();
+  missingTarget.targetFile.clear();
+  const RecordingMutationPlan missingTargetPlan =
+    planner.buildMovePlan(missingTarget, policy);
+  assert(!missingTargetPlan.executable);
+  assert(hasBlocker(
+    missingTargetPlan,
+    RecordingConstraint::MoveTargetMissing));
+
+  RecordingMutationAnalysis sameTarget = baseMoveAnalysis();
+  sameTarget.targetFile = sameTarget.recordingFile;
+  const RecordingMutationPlan sameTargetPlan =
+    planner.buildMovePlan(sameTarget, policy);
+  assert(!sameTargetPlan.executable);
+  assert(hasBlocker(
+    sameTargetPlan,
+    RecordingConstraint::MoveTargetSameAsSource));
+
+  RecordingMutationAnalysis targetExists = baseMoveAnalysis();
+  targetExists.constraints.push_back(
+    RecordingConstraint::MoveTargetExists);
+  const RecordingMutationPlan targetExistsPlan =
+    planner.buildMovePlan(targetExists, policy);
+  assert(!targetExistsPlan.executable);
+  assert(hasBlocker(
+    targetExistsPlan,
+    RecordingConstraint::MoveTargetExists));
+
+  RecordingMutationAnalysis activeRecording = baseMoveAnalysis();
+  activeRecording.constraints.push_back(
+    RecordingConstraint::LocalTimerActive);
+  const RecordingMutationPlan activeRecordingPlan =
+    planner.buildMovePlan(activeRecording, policy);
+  assert(!activeRecordingPlan.executable);
+  assert(hasBlocker(
+    activeRecordingPlan,
+    RecordingConstraint::LocalTimerActive));
+
+  RecordingMutationAnalysis replaying = baseMoveAnalysis();
+  replaying.constraints.push_back(
+    RecordingConstraint::ReplayActive);
+  const RecordingMutationPlan replayingPlan =
+    planner.buildMovePlan(replaying, policy);
+  assert(!replayingPlan.executable);
+  assert(hasBlocker(
+    replayingPlan,
+    RecordingConstraint::ReplayActive));
+
+  assert(
+    std::string(RecordingConstraintName(
+      RecordingConstraint::MoveTargetInvalid)) ==
+    "move-target-invalid");
+  assert(
+    std::string(RecordingMutationStepName(
+      RecordingMutationStep::MoveRecording)) ==
+    "move-recording");
+
+  return 0;
+}

--- a/tests/test_recording_move_preflight.cpp
+++ b/tests/test_recording_move_preflight.cpp
@@ -1,0 +1,144 @@
+#include "../recordingpreflight.h"
+
+#include <algorithm>
+#include <cassert>
+#include <map>
+#include <string>
+
+namespace {
+
+class FakeRecordingLookup : public IRecordingLookup
+{
+public:
+  std::map<std::string, RecordingLookupResult> results;
+
+  RecordingLookupResult find(const std::string& recordingFile) const override
+  {
+    const auto result = results.find(recordingFile);
+    return result == results.end() ? RecordingLookupResult() : result->second;
+  }
+};
+
+class FakeReplayLookup : public IRecordingReplayLookup
+{
+public:
+  bool replaying = false;
+
+  bool isReplaying(const std::string&) const override
+  {
+    return replaying;
+  }
+};
+
+class FakeHandlerLookup : public IRecordingHandlerLookup
+{
+public:
+  RecordingHandlerLookupResult result{true, false};
+
+  RecordingHandlerLookupResult getUsage(const std::string&) const override
+  {
+    return result;
+  }
+};
+
+class FakeLocalTimerLookup : public IRecordingLocalTimerLookup
+{
+public:
+  RecordingLocalTimerLookupResult result{true, false};
+
+  RecordingLocalTimerLookupResult findActive(const std::string&) const override
+  {
+    return result;
+  }
+};
+
+class FakeRemoteTimerLookup : public IRecordingRemoteTimerLookup
+{
+public:
+  RecordingRemoteTimerLookupResult result{true, false, 0, ""};
+
+  RecordingRemoteTimerLookupResult findActive(const std::string&) const override
+  {
+    return result;
+  }
+};
+
+class FakeSearchTimerLookup : public IRecordingSearchTimerLookup
+{
+public:
+  RecordingSearchTimerLookupResult result{true, false, -1};
+
+  RecordingSearchTimerLookupResult findOrigin(const std::string&) const override
+  {
+    return result;
+  }
+};
+
+bool contains(const std::vector<std::string>& values, const std::string& value)
+{
+  return std::find(values.begin(), values.end(), value) != values.end();
+}
+
+}
+
+int main()
+{
+  const std::string source = "/srv/vdr/video/Source/2026-07-14.20.00.1-0.rec";
+  const std::string target = "/srv/vdr/video/Target/2026-07-14.20.00.1-0.rec";
+
+  FakeRecordingLookup recordingLookup;
+  recordingLookup.results[source] = {true, source};
+  FakeReplayLookup replayLookup;
+  FakeHandlerLookup handlerLookup;
+  FakeLocalTimerLookup localTimerLookup;
+  FakeRemoteTimerLookup remoteTimerLookup;
+  FakeSearchTimerLookup searchTimerLookup;
+
+  RecordingMoveAnalyzer analyzer(
+    recordingLookup,
+    replayLookup,
+    handlerLookup,
+    localTimerLookup,
+    remoteTimerLookup,
+    searchTimerLookup);
+  RecordingMutationPlanner planner;
+  RecordingMovePreflightService service(analyzer, planner);
+  RecordingMutationPolicy policy;
+
+  const RecordingMovePreflightResult ready = service.preview(source, target, policy);
+  assert(ready.executable);
+  assert(ready.recordingFile == source);
+  assert(ready.targetFile == target);
+  assert(ready.constraints.empty());
+  assert(ready.blockers.empty());
+  assert(contains(ready.steps, "move-recording"));
+  assert(contains(ready.steps, "refresh-recordings"));
+  assert(contains(ready.steps, "notify-change"));
+  assert(ready.revision.recordingFile == source);
+  assert(ready.revision.targetFile == target);
+  assert(ready.revision.recordingsState != 0);
+  assert(ready.revision.timersState != 0);
+
+  const RecordingMovePreflightResult missingTarget = service.preview(source, "", policy);
+  assert(!missingTarget.executable);
+  assert(contains(missingTarget.constraints, "move-target-missing"));
+  assert(contains(missingTarget.blockers, "move-target-missing"));
+
+  recordingLookup.results[target] = {true, target};
+  const RecordingMovePreflightResult collision = service.preview(source, target, policy);
+  assert(!collision.executable);
+  assert(contains(collision.constraints, "move-target-exists"));
+  assert(contains(collision.blockers, "move-target-exists"));
+  assert(collision.revision.recordingsState != ready.revision.recordingsState);
+
+  replayLookup.replaying = true;
+  const RecordingMovePreflightResult replayBlocked = service.preview(
+    source,
+    "/srv/vdr/video/Other/2026-07-14.20.00.1-0.rec",
+    policy);
+  assert(!replayBlocked.executable);
+  assert(contains(replayBlocked.constraints, "replay-active"));
+  assert(contains(replayBlocked.blockers, "replay-active"));
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

This pull request adds safe native VDR recording mutation workflows for trash and move operations.

It introduces optimistic-locking APIs with preview, validation, and execution stages:

### Trash

- `POST /recordings/trash/preview.json`
- `POST /recordings/trash/validate.json`
- `POST /recordings/trash.json`

### Move

- `POST /recordings/move/preview.json`
- `POST /recordings/move/validate.json`
- `POST /recordings/move.json`

## Safety model

The workflows:

- analyze recording state before execution
- check replay, recording handler, local recording, timer, remote timer, and SearchTimer state
- fail closed when safety state cannot be established
- fingerprint recording and timer state during preview
- validate the same revision immediately before execution
- repeat critical checks under VDR locks
- use native VDR recording mutation behavior
- verify filesystem and VDR-list postconditions
- support safe idempotent retries

The APIs do not automatically stop playback, stop recordings, modify timers, or resolve active VDR handler operations.

## Recording trash

Trash follows native VDR semantics by changing `.rec` to `.del`. It supports an immediate idempotent `already-trashed` result while the native `.del` directory remains present.

## Recording move

Move accepts complete source and target recording identities, detects target collisions, updates the VDR recording list, runs the native `vdr-recordingaction rename` hook, and supports idempotent `already-moved` retries.

## Main changes

- shared recording mutation planning and policy model
- recording analysis providers and fail-closed constraints
- trash and move preflight services
- revision-based execution gates
- preview, validate, and execute HTTP responders
- native VDR trash and move executors
- server routing and Makefile wiring
- focused unit tests
- `RECORDING_TRASH_API.md`
- `RECORDING_MOVE_API.md`

## Verified tests

- focused recording trash tests
- `make test-recording-move-plan`
- `make test-recording-move-analysis`
- `make test-recording-move-preflight`
- `make test-recording-move-execution-gate`
- complete plugin build with `make -j"$(nproc)"`
- `git diff --check`

## Verified real VDR integration

Trash was verified with completed, active-recording, and active-replay cases, including missing and stale revisions and idempotent retries.

Move was tested against a running VDR installation with a 285 MB completed recording:

- preview: `HTTP 200`, executable, no filesystem mutation
- validate: `HTTP 200`, `status: ready`
- missing revision: `HTTP 400`
- stale revision: `HTTP 409`
- unsupported method: `HTTP 501`
- real move: `HTTP 200`, `status: moved`
- source removed and target present with unchanged size
- old VDR recording identity absent
- new VDR recording identity present
- native `vdr-recordingaction rename` hook executed
- identical retry: `HTTP 200`, `status: already-moved`
- reverse move back to the original identity succeeded
